### PR TITLE
fix: iterate through response headers correctly 

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -26,8 +26,10 @@ function request (requestOptions) {
     .then(response => {
       status = response.status
 
-      for (const keyAndValue of response.headers.entries()) {
-        headers[keyAndValue[0]] = keyAndValue[1]
+      if (response.headers.entries) {
+        for (const keyAndValue of response.headers.entries()) {
+          headers[keyAndValue[0]] = keyAndValue[1]
+        }
       }
 
       if (status === 204 || status === 205) {


### PR DESCRIPTION
Otherwise we get the following error:

```
HttpError: response.headers.entries(...) is not a function or its return value is not iterable
```

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>