### PR TITLE
test: remove unecessary dependency to `sinon-chai`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3910,14 +3910,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3932,20 +3930,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4062,8 +4057,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4075,7 +4069,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4090,7 +4083,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4098,14 +4090,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4124,7 +4114,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4205,8 +4194,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4218,7 +4206,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4340,7 +4327,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -9655,7 +9641,6 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -9980,8 +9965,7 @@
         "is-buffer": {
           "version": "1.1.6",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
@@ -10065,7 +10049,6 @@
           "version": "3.2.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -10112,8 +10095,7 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "lru-cache": {
           "version": "4.1.3",
@@ -10379,8 +10361,7 @@
         "repeat-string": {
           "version": "1.6.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "require-directory": {
           "version": "2.1.1",
@@ -12159,12 +12140,6 @@
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/simple-mock/-/simple-mock-0.8.0.tgz",
       "integrity": "sha1-ScmiI/pu6o4sT9aUj+gwDNillPM=",
-      "dev": true
-    },
-    "sinon-chai": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.2.0.tgz",
-      "integrity": "sha512-Z72B4a0l0IQe5uWi9yzcqX/Ml6K9e1Hp03NmkjJnRG3gDsKTX7KvLFZsVUmCaz0eqeXLLK089mwTsP1P1W+DUQ==",
       "dev": true
     },
     "slash": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "nyc": "^13.1.0",
     "semantic-release": "^15.10.5",
     "simple-mock": "^0.8.0",
-    "sinon-chai": "^3.2.0",
     "standard": "^12.0.1",
     "webpack": "^4.22.0",
     "webpack-bundle-analyzer": "^3.0.3",

--- a/test/defaults-test.js
+++ b/test/defaults-test.js
@@ -1,12 +1,10 @@
 const chai = require('chai')
 const fetchMock = require('fetch-mock/es5/server')
-const sinonChai = require('sinon-chai')
 
 const octokitRequest = require('..')
 const mockable = require('../lib/fetch')
 
 const expect = chai.expect
-chai.use(sinonChai)
 
 describe('endpoint.defaults()', () => {
   it('is a function', () => {

--- a/test/request-test.js
+++ b/test/request-test.js
@@ -1,12 +1,10 @@
 const chai = require('chai')
 const getUserAgent = require('universal-user-agent')
 const fetchMock = require('fetch-mock/es5/server')
-const sinonChai = require('sinon-chai')
 
 const octokitRequest = require('..')
 const mockable = require('../lib/fetch')
 
-chai.use(sinonChai)
 const expect = chai.expect
 const originalFetch = mockable.fetch
 


### PR DESCRIPTION
I noticed the following error when running `npm install`:
```
npm WARN sinon-chai@3.2.0 requires a peer of sinon@>=4.0.0 <7.0.0 but none is installed. You must install peer dependencies yourself.
```

So I was wondering how the tests could work without the necessary dependency to `sinon`. Turns out sinon is not used by the tests so the dependency to `sinon-chai` can be removed.