### PR TITLE
error.request

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,12 @@ All other options will passed depending on the `method` and `url` options.
   </tr>
 </table>
 
+If an error occurs, the `error` instance has additional properties to help with debugging
+
+- `error.status` The http response status code
+- `error.headers` The http response headers as an object
+- `error.request` The request options such as `method`, `url` and `data`
+
 ## `octokitRequest.defaults()`
 
 Override or set default options. Example:

--- a/lib/http-error.js
+++ b/lib/http-error.js
@@ -1,5 +1,5 @@
 module.exports = class HttpError extends Error {
-  constructor (message, statusCode, headers) {
+  constructor (message, statusCode, headers, request) {
     super(message)
 
     // Maintains proper stack trace (only available on V8)
@@ -17,5 +17,6 @@ module.exports = class HttpError extends Error {
       }
     })
     this.headers = headers
+    this.request = request
   }
 }

--- a/lib/request.js
+++ b/lib/request.js
@@ -40,19 +40,19 @@ function request (requestOptions) {
           return
         }
 
-        throw new HttpError(response.statusText, status, headers)
+        throw new HttpError(response.statusText, status, headers, requestOptions)
       }
 
       if (status === 304) {
         requestOptions.url = response.headers.location
-        throw new HttpError('Not modified', status, headers)
+        throw new HttpError('Not modified', status, headers, requestOptions)
       }
 
       if (status >= 400) {
         return response.text()
 
           .then(message => {
-            const error = new HttpError(message, status, headers)
+            const error = new HttpError(message, status, headers, requestOptions)
 
             try {
               Object.assign(error, JSON.parse(error.message))
@@ -89,6 +89,6 @@ function request (requestOptions) {
         throw error
       }
 
-      throw new HttpError(error.message, 500, headers)
+      throw new HttpError(error.message, 500, headers, requestOptions)
     })
 }

--- a/test/request-test.js
+++ b/test/request-test.js
@@ -239,6 +239,8 @@ describe('octokitRequest()', () => {
 
       .catch(error => {
         expect(error.status).to.equal(404)
+        expect(error.request.method).to.equal('GET')
+        expect(error.request.url).to.equal('https://api.github.com/orgs/nope')
       })
   })
 
@@ -356,6 +358,9 @@ describe('octokitRequest()', () => {
     mockable.fetch = fetchMock.sandbox()
       .get('path:/orgs/nope', 404)
 
+    const consoleWarn = console.warn
+    let warnCalled = 0
+    console.warn = () => warnCalled++
     return octokitRequest('GET /orgs/:org', {
       org: 'nope'
     })
@@ -366,6 +371,8 @@ describe('octokitRequest()', () => {
 
       .catch(error => {
         expect(error.code).to.equal(404)
+        expect(warnCalled).to.equal(1)
+        console.warn = consoleWarn
       })
   })
 })


### PR DESCRIPTION
In case of an HTTP error, you can now inspect `error.request` to find out which request caused the problem

```js
request(options).catch(error => {
  const {method, url} = error.request
  console.error(`Error occurred for "${method} ${url}": ${error.message}`)
})
```

-----

[View rendered README.md](https://github.com/octokit/request.js/blob/error-request/README.md)