### PR TITLE
feat: store request url in HttpError

### DIFF
--- a/lib/http-error.js
+++ b/lib/http-error.js
@@ -1,5 +1,5 @@
 module.exports = class HttpError extends Error {
-  constructor (message, statusCode, headers, request) {
+  constructor (url, message, statusCode, headers, request) {
     super(message)
 
     // Maintains proper stack trace (only available on V8)
@@ -8,6 +8,7 @@ module.exports = class HttpError extends Error {
       Error.captureStackTrace(this, this.constructor)
     }
 
+    this.url = url
     this.name = 'HttpError'
     this.status = statusCode
     Object.defineProperty(this, 'code', {

--- a/lib/request.js
+++ b/lib/request.js
@@ -40,19 +40,19 @@ function request (requestOptions) {
           return
         }
 
-        throw new HttpError(response.statusText, status, headers, requestOptions)
+        throw new HttpError(requestOptions.url, response.statusText, status, headers, requestOptions)
       }
 
       if (status === 304) {
         requestOptions.url = response.headers.location
-        throw new HttpError('Not modified', status, headers, requestOptions)
+        throw new HttpError(requestOptions.url, 'Not modified', status, headers, requestOptions)
       }
 
       if (status >= 400) {
         return response.text()
 
           .then(message => {
-            const error = new HttpError(message, status, headers, requestOptions)
+            const error = new HttpError(requestOptions.url, message, status, headers, requestOptions)
 
             try {
               Object.assign(error, JSON.parse(error.message))
@@ -89,6 +89,6 @@ function request (requestOptions) {
         throw error
       }
 
-      throw new HttpError(error.message, 500, headers, requestOptions)
+      throw new HttpError(requestOptions.url, error.message, 500, headers, requestOptions)
     })
 }


### PR DESCRIPTION
Very helpful for debugging purposes. I'm getting various
`HttpError` instances, and its very hard to understand the reason
without knowing what resource you are requesting.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>