### PR TITLE
Redact credentials from error.request

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ the passed options and sends the request using [fetch](https://developer.mozilla
 
 <!-- toc -->
 
+- [Features](#features)
 - [Usage](#usage)
   * [Node](#node)
   * [Browser](#browser)
@@ -34,6 +35,28 @@ the passed options and sends the request using [fetch](https://developer.mozilla
 - [LICENSE](#license)
 
 <!-- tocstop -->
+
+## Features
+
+🤩 1:1 mapping of REST API endpoint documentation, e.g. [Add labels to an issue](https://developer.github.com/v3/issues/labels/#add-labels-to-an-issue) becomes
+
+  ```js
+  request('POST /repos/:owner/:repo/issues/:number/labels', {
+    headers: {
+      accept: 'application/vnd.github.symmetra-preview+json'
+    },
+    labels: ['🐛 bug']
+  })
+  ```
+👍 Sensible defaults
+
+- `baseUrl`: `https://api.github.com`
+- `headers.accept`: `application/vnd.github.v3+json`
+- `headers.agent`: `octokit-request.js/<current version> <OS information>`, e.g. `octokit-request.js/1.2.3 Node.js/10.15.0 (macOS Mojave; x64)`
+
+🧐 Simple to debug: Sets `error.request` to request options causing the error (with redacted credentials).  
+
+👶 Small bundle size (\<5kb minified + gzipped)
 
 ## Usage
 

--- a/lib/http-error.js
+++ b/lib/http-error.js
@@ -17,6 +17,19 @@ module.exports = class HttpError extends Error {
       }
     })
     this.headers = headers
-    this.request = request
+
+    // redact request credentials without mutating original request options
+    const requestCopy = Object.assign({}, request)
+    if (request.headers.authorization) {
+      requestCopy.headers = Object.assign({}, request.headers, {
+        authorization: request.headers.authorization.replace(/ .*$/, ' [REDACTED]')
+      })
+    }
+
+    // client_id & client_secret can be passed as URL query parameters to increase rate limit
+    // see https://developer.github.com/v3/#increasing-the-unauthenticated-rate-limit-for-oauth-applications
+    requestCopy.url = requestCopy.url.replace(/\bclient_secret=\w+/g, 'client_secret=[REDACTED]')
+
+    this.request = requestCopy
   }
 }

--- a/lib/request.js
+++ b/lib/request.js
@@ -44,7 +44,6 @@ function request (requestOptions) {
       }
 
       if (status === 304) {
-        requestOptions.url = response.headers.location
         throw new HttpError('Not modified', status, headers, requestOptions)
       }
 

--- a/test/request-test.js
+++ b/test/request-test.js
@@ -354,6 +354,39 @@ describe('octokitRequest()', () => {
       })
   })
 
+  it('redacts credentials from error.request.headers.authorization', () => {
+    mockable.fetch = fetchMock.sandbox()
+      .get('https://api.github.com/', {
+        status: 500
+      })
+
+    return octokitRequest('/', {
+      headers: {
+        authorization: 'token secret123'
+      }
+    })
+
+      .catch(error => {
+        expect(error.request.headers.authorization).to.equal('token [REDACTED]')
+      })
+  })
+
+  it('redacts credentials from error.request.url', () => {
+    mockable.fetch = fetchMock.sandbox()
+      .get('https://api.github.com/?client_id=123&client_secret=secret123', {
+        status: 500
+      })
+
+    return octokitRequest('/', {
+      client_id: '123',
+      client_secret: 'secret123'
+    })
+
+      .catch(error => {
+        expect(error.request.url).to.equal('https://api.github.com/?client_id=123&client_secret=[REDACTED]')
+      })
+  })
+
   it('error.code (deprecated)', () => {
     mockable.fetch = fetchMock.sandbox()
       .get('path:/orgs/nope', 404)


### PR DESCRIPTION
closes #32, ref octokit/rest.js#1246

-----
[View rendered README.md](https://github.com/octokit/request.js/blob/32-redact-credentials-in-error/README.md)