### PR TITLE
feat(typescript): Allow to pass on type information for response data

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -9,7 +9,7 @@ export interface request {
    *
    * @param {object} endpoint Must set `method` and `url`. Plus URL, query or body parameters, as well as `headers`, `mediaType.{format|previews}`, `request`, or `baseUrl`.
    */
-  (options: Endpoint): Promise<AnyResponse>;
+  <T = any>(options: Endpoint): Promise<OctokitResponse<T>>;
 
   /**
    * Sends a request based on endpoint options
@@ -17,7 +17,7 @@ export interface request {
    * @param {string} route Request method + URL. Example: `'GET /orgs/:org'`
    * @param {object} [parameters] URL, query or body parameters, as well as `headers`, `mediaType.{format|previews}`, `request`, or `baseUrl`.
    */
-  (route: Route, parameters?: Parameters): Promise<AnyResponse>;
+  <T = any>(route: Route, parameters?: Parameters): Promise<OctokitResponse<T>>;
 
   /**
    * Returns a new `endpoint` with updated route and parameters


### PR DESCRIPTION
It is fully backwards compatible, since the default data type is still `any`