### PR TITLE
`options.request.hook`’s signature is now `(request, endpointOptions)`

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ const result = await request({
       Function
     </td>
     <td>
-     Function with the signature <code>hook(endpointOptions, request)</code>, where <code>endpointOptions</code> are the parsed options as returned by <a href="https://github.com/octokit/endpoint.js#endpointmergeroute-options-or-endpointmergeoptions"><code>endpoint.merge()</code></a>, and <code>request</code> is <a href="https://github.com/octokit/request.js#request"><code>request()</code></a>. This option works great in conjuction with <a href="https://github.com/gr2m/before-after-hook">before-after-hook</a>.
+     Function with the signature <code>hook(request, endpointOptions)</code>, where <code>endpointOptions</code> are the parsed options as returned by <a href="https://github.com/octokit/endpoint.js#endpointmergeroute-options-or-endpointmergeoptions"><code>endpoint.merge()</code></a>, and <code>request</code> is <a href="https://github.com/octokit/request.js#request"><code>request()</code></a>. This option works great in conjuction with <a href="https://github.com/gr2m/before-after-hook">before-after-hook</a>.
     </td>
   </tr>
   <tr>

--- a/src/with-defaults.ts
+++ b/src/with-defaults.ts
@@ -25,9 +25,9 @@ export default function withDefaults(
       return fetchWrapper(endpoint.parse(endpointOptions));
     }
 
-    return endpointOptions.request.hook(endpointOptions, (options: Defaults) =>
-      fetchWrapper(endpoint.parse(options))
-    );
+    return endpointOptions.request.hook((options: Defaults) => {
+      return fetchWrapper(endpoint.parse(options));
+    }, endpointOptions);
   };
 
   return Object.assign(newApi, {

--- a/test/request.test.ts
+++ b/test/request.test.ts
@@ -492,7 +492,7 @@ describe("request()", () => {
       .sandbox()
       .mock("https://api.github.com/", { ok: true });
 
-    const hook = (options: Endpoint, request: requestInterface) => {
+    const hook = (request: requestInterface, options: Endpoint) => {
       expect(options).toEqual({
         baseUrl: "https://api.github.com",
         headers: {


### PR DESCRIPTION
closes #71

-----
[View rendered README.md](https://github.com/octokit/request.js/blob/request-hook-signature/README.md)