### PR TITLE
pass request-compatible API to `request.hook(request, options)`

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,6 @@
 import { Agent } from "http";
 
 import { endpoint } from "@octokit/endpoint";
-import nodeFetch from "node-fetch";
 
 export interface request {
   /**

--- a/src/with-defaults.ts
+++ b/src/with-defaults.ts
@@ -25,9 +25,18 @@ export default function withDefaults(
       return fetchWrapper(endpoint.parse(endpointOptions));
     }
 
-    return endpointOptions.request.hook((options: Defaults) => {
-      return fetchWrapper(endpoint.parse(options));
-    }, endpointOptions);
+    const request = (route: Route | Endpoint, parameters?: Parameters) => {
+      return fetchWrapper(
+        endpoint.parse(endpoint.merge(<Route>route, parameters))
+      );
+    };
+
+    Object.assign(request, {
+      endpoint,
+      defaults: withDefaults.bind(null, endpoint)
+    });
+
+    return endpointOptions.request.hook(request, endpointOptions);
   };
 
   return Object.assign(newApi, {

--- a/test/request.test.ts
+++ b/test/request.test.ts
@@ -488,11 +488,19 @@ describe("request()", () => {
   });
 
   it("options.request.hook", function() {
-    const mock = fetchMock
-      .sandbox()
-      .mock("https://api.github.com/", { ok: true });
+    const mock = fetchMock.sandbox().mock(
+      "https://api.github.com/foo",
+      { ok: true },
+      {
+        headers: {
+          "x-foo": "bar"
+        }
+      }
+    );
 
     const hook = (request: requestInterface, options: Endpoint) => {
+      expect(request.endpoint).toBeInstanceOf(Function);
+      expect(request.defaults).toBeInstanceOf(Function);
       expect(options).toEqual({
         baseUrl: "https://api.github.com",
         headers: {
@@ -510,7 +518,15 @@ describe("request()", () => {
         },
         url: "/"
       });
-      return request(options);
+
+      return request("/foo", {
+        headers: {
+          "x-foo": "bar"
+        },
+        request: {
+          fetch: mock
+        }
+      });
     };
 
     return request("/", {


### PR DESCRIPTION
fixes #79