### PR TITLE
Add test for errors in OAuth endpoint

### DIFF
--- a/test/request.test.ts
+++ b/test/request.test.ts
@@ -748,4 +748,37 @@ x//0u+zd/R/QRUzLOw4N72/Hu+UG6MNt5iDZFCtapRaKt6OvSBwy8w==
         );
       });
   });
+
+  it("Error in /login/oauth/access_token", function() {
+    const errorDescription =
+      "The client_id and/or client_secret passed are incorrect.";
+
+    const mock = fetchMock
+      .sandbox()
+      .mock("https://github.com/login/oauth/access_token", {
+        status: 200,
+        body: JSON.stringify({
+          error: "incorrect_client_credentials",
+          error_description: errorDescription
+        }),
+        headers: {
+          "Content-Type": "application/json; charset=utf-8"
+        }
+      });
+
+    return request("POST https://github.com/login/oauth/access_token", {
+      headers: {
+        accept: "application/json",
+      },
+      request: {
+        fetch: mock
+      }
+    })
+      .then(() => {
+        fail("should not resolve");
+      })
+      .catch(error => {
+        expect(error).toHaveProperty("message", errorDescription);
+      });
+  });
 });


### PR DESCRIPTION
Follow up from https://github.com/octokit/auth-app.js/issues/26.

The `https://github.com/login/oauth/access_token` endpoint returns status code 200 on error, and @octokit/request doesn't reject the promise as it should be.

I'm adding the failing test suggested in https://github.com/octokit/auth-app.js/issues/26#issuecomment-549002493 in this library because it sounds that here is where it should be fixed. Additionally, I've noticed that there is repeated code for handling this endpoint in at least @octokit/auth-app and @octokit/auth-oauth-app, due to the fact that it isn't under `api.github.com` but `github.com`. It sounds like the special case should be programmed into @octokit/request. What do you think about this?