### PR TITLE
fix(README): typo in authentication section

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ const requestWithAuth = request.defaults({
     authorization: "token 0000000000000000000000000000000000000001",
   },
 });
-const result = await request("GET /user");
+const result = await requestWithAuth("GET /user");
 ```
 
 For more complex authentication strategies such as GitHub Apps or Basic, we recommend the according authentication library exported by [`@octokit/auth`](https://github.com/octokit/auth.js).


### PR DESCRIPTION
I tried the code snippet in the Authentication section and it didn't work. I changed it as shown in this commit and it worked. I assume that's the intended content?

-----
[View rendered README.md](https://github.com/orozcoadrian/request.js/blob/patch-1/README.md)