### PR TITLE
fix(deps): pin typescript version due to #137

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "semantic-release": "^17.0.0",
     "semantic-release-plugin-update-version-in-files": "^1.0.0",
     "ts-jest": "^25.1.0",
-    "typescript": "^3.4.5"
+    "typescript": "3.7.5"
   },
   "jest": {
     "preset": "ts-jest",


### PR DESCRIPTION
works around the regression introduced with the bump from Typescript v3.7.5 to v3.9.3 in #137