### PR TITLE
fix: bump minimal `node-fetch` version to `2.6.1` (security update)

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@octokit/types": "^5.0.0",
     "deprecation": "^2.0.0",
     "is-plain-object": "^5.0.0",
-    "node-fetch": "^2.3.0",
+    "node-fetch": "^2.6.1",
     "once": "^1.4.0",
     "universal-user-agent": "^6.0.0"
   },


### PR DESCRIPTION
fixes #260 /cc  @GuyKh 