### PR TITLE
feat: logs deprecation warning if `deprecation` header is present'

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,16 @@ const { data: app } = await requestWithAuth(
       Use an <code>AbortController</code> instance to cancel a request. In node you can only cancel streamed requests.
     </td>
   </tr>
+    <th align=left>
+      <code>options.request.log</code>
+    </th>
+    <th>
+      <code>object</code>
+    </th>
+    <td>
+      Used for internal logging. Defaults to <a href="https://developer.mozilla.org/en-US/docs/Web/API/console"><code>console</code></a>.
+    </td>
+  </tr>
   <tr>
     <th align=left>
       <code>options.request.timeout</code>

--- a/src/fetch-wrapper.ts
+++ b/src/fetch-wrapper.ts
@@ -10,6 +10,11 @@ export default function fetchWrapper(
     redirect?: "error" | "follow" | "manual";
   }
 ) {
+  const log =
+    requestOptions.request && requestOptions.request.log
+      ? requestOptions.request.log
+      : console;
+
   if (
     isPlainObject(requestOptions.body) ||
     Array.isArray(requestOptions.body)
@@ -44,6 +49,19 @@ export default function fetchWrapper(
 
       for (const keyAndValue of response.headers) {
         headers[keyAndValue[0]] = keyAndValue[1];
+      }
+
+      if ("deprecation" in headers) {
+        const matches =
+          headers.link && headers.link.match(/<([^>]+)>; rel="deprecation"/);
+        const deprecationLink = matches && matches.pop();
+        log.warn(
+          `[@octokit/request] "${requestOptions.method} ${
+            requestOptions.url
+          }" is deprecated. It is scheduled to be removed on ${headers.sunset}${
+            deprecationLink ? `. See ${deprecationLink}` : ""
+          }`
+        );
       }
 
       if (status === 204 || status === 205) {


### PR DESCRIPTION
closes #322


-----
[View rendered README.md](https://github.com/octokit/request.js/blob/332/log-deprecation-warnings/README.md)