### PR TITLE
feat: `error.response`

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,8 +416,8 @@ All other options except `options.request.*` will be passed depending on the `me
 If an error occurs, the `error` instance has additional properties to help with debugging
 
 - `error.status` The http response status code
-- `error.headers` The http response headers as an object
 - `error.request` The request options such as `method`, `url` and `data`
+- `error.response` The http response object with `url`, `headers`, and `data`
 
 ## `request.defaults()`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2294,9 +2294,9 @@
       }
     },
     "@octokit/request-error": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.5.tgz",
-      "integrity": "sha512-T/2wcCFyM7SkXzNoyVNWjyVlUwBvW3igM3Btr/eKYiPmucXTtkxt2RBsf6gn3LTzaLSLTQtNmvg+dGsOxQrjZg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.1.0.tgz",
+      "integrity": "sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==",
       "requires": {
         "@octokit/types": "^6.0.3",
         "deprecation": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "license": "MIT",
   "dependencies": {
     "@octokit/endpoint": "^6.0.1",
-    "@octokit/request-error": "^2.0.0",
+    "@octokit/request-error": "^2.1.0",
     "@octokit/types": "^6.16.1",
     "is-plain-object": "^5.0.0",
     "node-fetch": "^2.6.1",


### PR DESCRIPTION
This pull request updates `@octokit/request-error` to `^2.1.0`, which introduces the `error.response` property.

`error.headers` is still set, but is now considered deprecated


-----
[View rendered README.md](https://github.com/octokit/request.js/blob/error.response/README.md)