### PR TITLE
feat: special handling for `AbortError`

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,6 +419,8 @@ If an error occurs, the promise is rejected with an `error` object containing 3 
 - `error.request` The request options such as `method`, `url` and `data`
 - `error.response` The http response object with `url`, `headers`, and `data`
 
+If the error is due to an `AbortSignal` being used, the resulting `AbortError` is bubbled up to the caller.
+
 ## `request.defaults()`
 
 Override or set default options. Example:

--- a/src/fetch-wrapper.ts
+++ b/src/fetch-wrapper.ts
@@ -127,6 +127,7 @@ export default function fetchWrapper(
     })
     .catch((error) => {
       if (error instanceof RequestError) throw error;
+      else if (error.name === "AbortError") throw error;
 
       throw new RequestError(error.message, 500, {
         request: requestOptions,


### PR DESCRIPTION
## Description

This aims to address #362 and adds specific handling for `AbortError` being thrown during a request. In the present state of things, if a user were to pass an `AbortSignal` via `options.request.signal`, the resulting error gets lumped in with a generic `RequestError` and the fact that the request was aborted is obscured.

With the present changes, the `AbortError` is bubbled up (similarly to how `RequestError` instances thrown by `fetch` are) so that the user can handle it however they want.

I'm more than open to input if you have a better vision for what should be included in the error that's rethrown (i.e. if it should be wrapped the same way the catchall `RequestError` is) if simply bubbling up the `AbortError` isn't enough. Since request cancellation is intentional, I would expect that as long as whoever calls `request(...)` can know and handle it properly, not much more is needed.

This also tosses in a sample test case to cover this behaviour.

-----
[View rendered README.md](https://github.com/mcataford/request.js/blob/master/README.md)