### PR TITLE
doc: emphasize that failed requests result with rejected promise

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ All other options except `options.request.*` will be passed depending on the `me
 
 **Result**
 
-`request` returns a promise and resolves with 4 keys
+`request` returns a promise. If the request was successful, the promise resolves with an object containing 4 keys:
 
 <table>
   <thead>
@@ -413,7 +413,7 @@ All other options except `options.request.*` will be passed depending on the `me
   </tr>
 </table>
 
-If an error occurs, the `error` instance has additional properties to help with debugging
+If an error occurs, the promise is rejected with an `error` object containing 3 keys to help with debugging:
 
 - `error.status` The http response status code
 - `error.request` The request options such as `method`, `url` and `data`


### PR DESCRIPTION
The current docs do not make it explicit that the `Promise` returned from `request` is rejected on failure, so I reworded it to clarify that. Based on the following code:

https://github.com/octokit/request.js/blob/master/test/request.test.ts#L373-L391
https://github.com/octokit/request.js/blob/master/src/fetch-wrapper.ts#L100-L114

-----
[View rendered README.md](https://github.com/jakub-g/request.js/blob/patch-1/README.md)