### PR TITLE
Implement isomorphic fetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,8 @@
         "@octokit/endpoint": "^7.0.0",
         "@octokit/request-error": "^3.0.0",
         "@octokit/types": "^6.16.1",
+        "cross-fetch": "^3.1.5",
         "is-plain-object": "^5.0.0",
-        "node-fetch": "^2.6.7",
         "universal-user-agent": "^6.0.0"
       },
       "devDependencies": {
@@ -4095,6 +4095,14 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/cross-fetch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+      "dependencies": {
+        "node-fetch": "2.6.7"
       }
     },
     "node_modules/cross-spawn": {
@@ -13904,6 +13912,14 @@
         "is-directory": "^0.3.1",
         "js-yaml": "^3.13.1",
         "parse-json": "^4.0.0"
+      }
+    },
+    "cross-fetch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+      "requires": {
+        "node-fetch": "2.6.7"
       }
     },
     "cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "@octokit/endpoint": "^7.0.0",
     "@octokit/request-error": "^3.0.0",
     "@octokit/types": "^6.16.1",
+    "cross-fetch": "^3.1.5",
     "is-plain-object": "^5.0.0",
-    "node-fetch": "^2.6.7",
     "universal-user-agent": "^6.0.0"
   },
   "devDependencies": {

--- a/src/fetch-wrapper.ts
+++ b/src/fetch-wrapper.ts
@@ -1,5 +1,6 @@
 import { isPlainObject } from "is-plain-object";
-import nodeFetch, { HeadersInit, Response } from "node-fetch";
+import isomorphicFetch, { Response } from "cross-fetch";
+import { HeadersInit } from "node-fetch";
 import { RequestError } from "@octokit/request-error";
 import { EndpointInterface } from "@octokit/types";
 
@@ -26,8 +27,8 @@ export default function fetchWrapper(
   let status: number;
   let url: string;
 
-  const fetch: typeof nodeFetch =
-    (requestOptions.request && requestOptions.request.fetch) || nodeFetch;
+  const fetch: typeof isomorphicFetch =
+    (requestOptions.request && requestOptions.request.fetch) || isomorphicFetch;
 
   return fetch(
     requestOptions.url,

--- a/src/get-buffer-response.ts
+++ b/src/get-buffer-response.ts
@@ -1,4 +1,4 @@
-import { Response } from "node-fetch";
+import { Response } from "cross-fetch";
 export default function getBufferResponse(response: Response) {
   return response.arrayBuffer();
 }

--- a/test/request.test.ts
+++ b/test/request.test.ts
@@ -3,7 +3,8 @@ import stream from "stream";
 
 import { getUserAgent } from "universal-user-agent";
 import fetchMock from "fetch-mock";
-import { Headers, RequestInit } from "node-fetch";
+import { Headers } from "cross-fetch";
+import { RequestInit } from "node-fetch";
 import { createAppAuth } from "@octokit/auth-app";
 import lolex from "lolex";
 import {


### PR DESCRIPTION
As stated in #456, this library seems to be for both the browser and Node.js; however, it uses `node-fetch` which is a request library specifically for Node because it uses modules not present in the browser. This PR implements an isomorphic fetch using `cross-fetch` so that it can properly run in the browser. It maintains the `@types/node-fetch` package as a dev dependency so that certain type casts still work.