### PR TITLE
ci(codeql): ignore on push events for dependabot branches

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,6 +2,8 @@ name: "Code scanning - action"
 
 on:
   push:
+    branches-ignore:
+      - "dependabot/**"
   pull_request:
   schedule:
     - cron: '0 13 * * 5'


### PR DESCRIPTION
# Description
Do not run codeql.yml for dependabot branches

# Context
https://github.com/octokit/plugin-paginate-rest.js/pull/376