### PR TITLE
refactor: failover from native fetch to node-fetch

### DIFF
--- a/src/fetch-wrapper.ts
+++ b/src/fetch-wrapper.ts
@@ -27,7 +27,9 @@ export default function fetchWrapper(
   let url: string;
 
   const fetch: typeof nodeFetch =
-    (requestOptions.request && requestOptions.request.fetch) || nodeFetch;
+    (requestOptions.request && requestOptions.request.fetch) ||
+    globalThis.fetch ||
+    /* istanbul ignore next */ nodeFetch;
 
   return fetch(
     requestOptions.url,
@@ -115,7 +117,6 @@ export default function fetchWrapper(
 
       return getResponseData(response);
     })
-
     .then((data) => {
       return {
         status,
@@ -124,7 +125,6 @@ export default function fetchWrapper(
         data,
       };
     })
-
     .catch((error) => {
       if (error instanceof RequestError) throw error;
 


### PR DESCRIPTION
`fetch` API has landed in Node.js 18 (and is available in modern browsers, Deno, Clodflare, etc). Failover from native `fetch` to `node-fetch` makes us confident that there will be no issues  when `node-fetch` is removed (say in 2046).

A new pattern of testing is made possible: instead of creating new instances of `Octokit` in test cases (with different fetch mocks), I can simply stub `globalThis.fetch` in test cases using a same instance of `Octokit` (imported from non-test code).

In some rare cases, this PR may break existing code. But generally I think it is safe.