### PR TITLE
fix: add `duplex` option when sending a body

### DIFF
--- a/src/fetch-wrapper.ts
+++ b/src/fetch-wrapper.ts
@@ -39,6 +39,7 @@ export default function fetchWrapper(
         body: requestOptions.body,
         headers: requestOptions.headers as HeadersInit,
         redirect: requestOptions.redirect,
+        ...(requestOptions.body && { duplex: 'half' })
       },
       // `requestOptions.request.agent` type is incompatible
       // see https://github.com/octokit/types.ts/pull/264


### PR DESCRIPTION

Resolves #570

Refs https://github.com/nodejs/node/issues/46221.

Adds missing `duplex` option to `fetch-wrapper` as now required: https://github.com/whatwg/fetch/pull/1457

----

## Behavior

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

`fetch` calls fail with the following type of error:

```
Uncaught TypeError: RequestInit: duplex option is required when sending a body.
    at new Request (node:internal/deps/undici/undici:7090:19)
```

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

 `fetch` calls should no longer fail.


### Other information
<!-- Any other information that is important to this PR  -->

*

----

## Additional info

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/main/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [ ] No

If `Yes`, what's the impact:

* N/A


### Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please add the corresponding label for change this PR introduces:
- Bugfix: `Type: Bug`
- Feature/model/API additions: `Type: Feature`
- Updates to docs or samples: `Type: Documentation`
- Dependencies/code cleanup: `Type: Maintenance`

----

