### PR TITLE
docs: replace references to Skypack CDN with esm.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,11 @@ request("POST /repos/{owner}/{repo}/issues/{number}/labels", {
 <tr><th>
 Browsers
 </th><td width=100%>
-Load <code>@octokit/request</code> directly from <a href="https://cdn.skypack.dev">cdn.skypack.dev</a>
+Load <code>@octokit/request</code> directly from <a href="https://esm.sh">esm.sh</a>
 
 ```html
 <script type="module">
-  import { request } from "https://cdn.skypack.dev/@octokit/request";
+  import { request } from "https://esm.sh/@octokit/request";
 </script>
 ```
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ the passed options and sends the request using [fetch](https://developer.mozilla
 - [`request.defaults()`](#requestdefaults)
 - [`request.endpoint`](#requestendpoint)
 - [Special cases](#special-cases)
-  - [The `data` parameter – set request body directly](#the-data-parameter--set-request-body-directly)
+  - [The `data` parameter – set request body directly](#the-data-parameter-%E2%80%93-set-request-body-directly)
   - [Set parameters for both the URL/query and the request body](#set-parameters-for-both-the-urlquery-and-the-request-body)
 - [LICENSE](#license)
 


### PR DESCRIPTION
The Skypack CDN is no longer maintained, so we should remove references to it.