### PR TITLE
fix(deps): upgrade `@octokit/endpoint`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-development",
       "license": "MIT",
       "dependencies": {
-        "@octokit/endpoint": "^8.0.0",
+        "@octokit/endpoint": "^8.0.1",
         "@octokit/request-error": "^4.0.1",
         "@octokit/types": "^10.0.0",
         "is-plain-object": "^5.0.0",
@@ -1988,9 +1988,9 @@
       }
     },
     "node_modules/@octokit/endpoint": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-8.0.0.tgz",
-      "integrity": "sha512-tpIP5+zno0zRLfDJ07iFmWfORiLmWY2NjwVm3gCLio+1LiM3umPEQnOcZrkMXjupLsVVEkZwysmHvc6flrlLQw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-8.0.1.tgz",
+      "integrity": "sha512-tVviBdPuf3kcCiIvXYDJg7NAJrkTh8QEnc+UCybknKdEBCjIi7uQbFX3liQrpk1m5PjwC7fUJg08DYZ4F+l1RQ==",
       "dependencies": {
         "@octokit/types": "^10.0.0",
         "is-plain-object": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "author": "Gregor Martynus (https://github.com/gr2m)",
   "license": "MIT",
   "dependencies": {
-    "@octokit/endpoint": "^8.0.0",
+    "@octokit/endpoint": "^8.0.1",
     "@octokit/request-error": "^4.0.1",
     "@octokit/types": "^10.0.0",
     "is-plain-object": "^5.0.0",


### PR DESCRIPTION
For some reason, clients are not getting the updated version of `@octokit/endpoint` via other packages that require `@octokit/request`

See [the following issue in `@octokit/graphql`](https://github.com/octokit/graphql.js/issues/485)

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->


<!-- Issues are required for both bug fixes and features. -->
Resolves #ISSUE_NUMBER

----

## Behavior

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* This package had a dependency on `^8.0.0` and `8.0.0` contains a bug for graphql previews
* Clients would get this bad version

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Upgrades the version required to be at least the fixed version
* Clients should get the fixed version

### Other information
<!-- Any other information that is important to this PR  -->

*

----

## Additional info

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/main/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

If `Yes`, what's the impact:

* N/A


### Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please add the corresponding label for change this PR introduces:
- Dependencies/code cleanup: `Type: Maintenance`

----

