### PR TITLE
feat: v8

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ const { data: app } = await requestWithAuth(
       Array of strings
     </td>
     <td>
-      Name of previews, such as `mercy`, `symmetra`, or `scarlet-witch`. See <a href="https://developer.github.com/v3/previews/">API Previews</a>.
+      Name of previews, such as `mercy`, `symmetra`, or `scarlet-witch`. See <a href="https://docs.github.com/graphql/overview/schema-previews">GraphQL Schema Previews</a>.
       Note that these only apply to GraphQL requests and have no effect on REST routes.
     </td>
   </tr>

--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ const { data: app } = await requestWithAuth(
     </td>
     <td>
       Name of previews, such as `mercy`, `symmetra`, or `scarlet-witch`. See <a href="https://developer.github.com/v3/previews/">API Previews</a>.
+      Note that these only apply to GraphQL requests and have no effect on REST routes.
     </td>
   </tr>
   <tr>

--- a/README.md
+++ b/README.md
@@ -267,17 +267,6 @@ const { data: app } = await requestWithAuth(
   </tr>
   <tr>
     <th align=left>
-      <code>options.method</code>
-    </th>
-    <td>
-      String
-    </td>
-    <td>
-      Any supported <a href="https://developer.github.com/v3/#http-verbs">http verb</a>, case insensitive. <em>Defaults to <code>Get</code></em>.
-    </td>
-  </tr>
-  <tr>
-    <th align=left>
       <code>options.url</code>
     </th>
     <td>
@@ -299,18 +288,7 @@ const { data: app } = await requestWithAuth(
       Set request body directly instead of setting it to JSON based on additional parameters. See <a href="#data-parameter">"The `data` parameter"</a> below.
     </td>
   </tr>
-  <tr>
-    <th align=left>
-      <a name="options-request-agent"></a>
-      <code>options.request.agent</code>
-    </th>
-    <td>
-      <a href="https://nodejs.org/api/http.html#http_class_http_agent">http(s).Agent</a> instance
-    </td>
-    <td>
-     Node only. Useful for custom proxy, certificate, or dns lookup.
-    </td>
-  </tr>
+
   <tr>
     <th align=left>
       <code>options.request.fetch</code>

--- a/README.md
+++ b/README.md
@@ -245,6 +245,17 @@ const { data: app } = await requestWithAuth(
   </tr>
   <tr>
     <th align=left>
+      <code>options.method</code>
+    </th>
+    <td>
+      String
+    </td>
+    <td>
+      Any supported <a href="https://developer.github.com/v3/#http-verbs">http verb</a>, case insensitive. <em>Defaults to <code>Get</code></em>.
+    </td>
+  </tr>
+  <tr>
+    <th align=left>
       <code>options.mediaType.format</code>
     </th>
     <td>

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@octokit/endpoint": "^8.0.1",
         "@octokit/request-error": "^4.0.1",
-        "@octokit/types": "^10.0.0",
+        "@octokit/types": "^10.1.0-beta.1",
         "is-plain-object": "^5.0.0",
         "universal-user-agent": "^6.0.0"
       },
@@ -2000,6 +2000,14 @@
         "node": ">= 18"
       }
     },
+    "node_modules/@octokit/endpoint/node_modules/@octokit/types": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-10.0.0.tgz",
+      "integrity": "sha512-Vm8IddVmhCgU1fxC1eyinpwqzXPEYu0NrYzD3YZjlGjyftdLBTeqNblRC0jmJmgxbJIsQlyogVeGnrNaaMVzIg==",
+      "dependencies": {
+        "@octokit/openapi-types": "^18.0.0"
+      }
+    },
     "node_modules/@octokit/oauth-authorization-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/oauth-authorization-url/-/oauth-authorization-url-5.0.0.tgz",
@@ -2083,6 +2091,14 @@
         "node": ">= 18"
       }
     },
+    "node_modules/@octokit/request-error/node_modules/@octokit/types": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-10.0.0.tgz",
+      "integrity": "sha512-Vm8IddVmhCgU1fxC1eyinpwqzXPEYu0NrYzD3YZjlGjyftdLBTeqNblRC0jmJmgxbJIsQlyogVeGnrNaaMVzIg==",
+      "dependencies": {
+        "@octokit/openapi-types": "^18.0.0"
+      }
+    },
     "node_modules/@octokit/request/node_modules/@octokit/endpoint": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.6.tgz",
@@ -2113,9 +2129,9 @@
       "dev": true
     },
     "node_modules/@octokit/types": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-10.0.0.tgz",
-      "integrity": "sha512-Vm8IddVmhCgU1fxC1eyinpwqzXPEYu0NrYzD3YZjlGjyftdLBTeqNblRC0jmJmgxbJIsQlyogVeGnrNaaMVzIg==",
+      "version": "10.1.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-10.1.0-beta.1.tgz",
+      "integrity": "sha512-f+/wnrTZBQld3Wbnh9IeTJt7OlOV1Nfn8tMvma8DbazjYGcl18yzIO42kyejtIcSbCID5cjMbizzTZUz/QV0Lw==",
       "dependencies": {
         "@octokit/openapi-types": "^18.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@octokit/endpoint": "^8.0.1",
         "@octokit/request-error": "^4.0.1",
-        "@octokit/types": "^10.1.0-beta.1",
+        "@octokit/types": "^11.0.0",
         "is-plain-object": "^5.0.0",
         "universal-user-agent": "^6.0.0"
       },
@@ -2129,9 +2129,9 @@
       "dev": true
     },
     "node_modules/@octokit/types": {
-      "version": "10.1.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-10.1.0-beta.1.tgz",
-      "integrity": "sha512-f+/wnrTZBQld3Wbnh9IeTJt7OlOV1Nfn8tMvma8DbazjYGcl18yzIO42kyejtIcSbCID5cjMbizzTZUz/QV0Lw==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-11.0.0.tgz",
+      "integrity": "sha512-h4iyfMpQUdub1itwTn6y7z2a3EtPuer1paKfsIbZErv0LBbZYGq6haiPUPJys/LetPqgcX3ft33O16XuS03Anw==",
       "dependencies": {
         "@octokit/openapi-types": "^18.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@octokit/endpoint": "^8.0.1",
     "@octokit/request-error": "^4.0.1",
-    "@octokit/types": "^10.0.0",
+    "@octokit/types": "^10.1.0-beta.1",
     "is-plain-object": "^5.0.0",
     "universal-user-agent": "^6.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@octokit/endpoint": "^8.0.1",
     "@octokit/request-error": "^4.0.1",
-    "@octokit/types": "^10.1.0-beta.1",
+    "@octokit/types": "^11.0.0",
     "is-plain-object": "^5.0.0",
     "universal-user-agent": "^6.0.0"
   },

--- a/src/fetch-wrapper.ts
+++ b/src/fetch-wrapper.ts
@@ -36,7 +36,7 @@ export default function fetchWrapper(
     );
   }
 
-  return fetch(requestOptions.url, requestOptions as any)
+  return fetch(requestOptions.url, { signal: (requestOptions as any).signal})
     .then(async (response) => {
       url = response.url;
       status = response.status;

--- a/src/fetch-wrapper.ts
+++ b/src/fetch-wrapper.ts
@@ -36,19 +36,16 @@ export default function fetchWrapper(
     );
   }
 
-  return fetch(
-    requestOptions.url,
-    {
-      method: requestOptions.method,
-      body: requestOptions.body,
-      headers: requestOptions.headers as HeadersInit,
-      signal: (requestOptions as any).signal,
-      data: (requestOptions as any).data,
-      // duplex must be set if request.body is ReadableStream or Async Iterables.
-      // See https://fetch.spec.whatwg.org/#dom-requestinit-duplex.
-      ...(requestOptions.body && { duplex: "half" }),
-    },
-  )
+  return fetch(requestOptions.url, {
+    method: requestOptions.method,
+    body: requestOptions.body,
+    headers: requestOptions.headers as HeadersInit,
+    signal: (requestOptions as any).signal,
+    data: (requestOptions as any).data,
+    // duplex must be set if request.body is ReadableStream or Async Iterables.
+    // See https://fetch.spec.whatwg.org/#dom-requestinit-duplex.
+    ...(requestOptions.body && { duplex: "half" }),
+  })
     .then(async (response) => {
       url = response.url;
       status = response.status;

--- a/src/fetch-wrapper.ts
+++ b/src/fetch-wrapper.ts
@@ -38,7 +38,7 @@ export default function fetchWrapper(
 
   return fetch(
     requestOptions.url,
-    Object.assign({
+    {
       method: requestOptions.method,
       body: requestOptions.body,
       headers: requestOptions.headers as HeadersInit,
@@ -47,7 +47,7 @@ export default function fetchWrapper(
       // duplex must be set if request.body is ReadableStream or Async Iterables.
       // See https://fetch.spec.whatwg.org/#dom-requestinit-duplex.
       ...(requestOptions.body && { duplex: "half" }),
-    }),
+    },
   )
     .then(async (response) => {
       url = response.url;

--- a/src/fetch-wrapper.ts
+++ b/src/fetch-wrapper.ts
@@ -36,7 +36,11 @@ export default function fetchWrapper(
     );
   }
 
-  return fetch(requestOptions.url, { signal: (requestOptions as any).signal})
+  return fetch(requestOptions.url,
+    { signal: (requestOptions as any).signal,
+      method: (requestOptions as any).method,
+      body: (requestOptions as any).body,
+      headers: (requestOptions as any).headers,})
     .then(async (response) => {
       url = response.url;
       status = response.status;

--- a/src/fetch-wrapper.ts
+++ b/src/fetch-wrapper.ts
@@ -36,7 +36,7 @@ export default function fetchWrapper(
     );
   }
 
-  return fetch(requestOptions.url, requestOptions as any || {})
+  return fetch(requestOptions.url, requestOptions as any)
     .then(async (response) => {
       url = response.url;
       status = response.status;

--- a/src/fetch-wrapper.ts
+++ b/src/fetch-wrapper.ts
@@ -36,19 +36,18 @@ export default function fetchWrapper(
     );
   }
 
-  return fetch(requestOptions.url,
-    Object.assign(
-      {
-        method: requestOptions.method,
-        body: requestOptions.body,
-        headers: requestOptions.headers as HeadersInit,
-        signal: (requestOptions as any).signal,
-        data: (requestOptions as any).data,
-        // duplex must be set if request.body is ReadableStream or Async Iterables.
-        // See https://fetch.spec.whatwg.org/#dom-requestinit-duplex.
-        ...(requestOptions.body && { duplex: "half" }),
-      },
-    ),
+  return fetch(
+    requestOptions.url,
+    Object.assign({
+      method: requestOptions.method,
+      body: requestOptions.body,
+      headers: requestOptions.headers as HeadersInit,
+      signal: (requestOptions as any).signal,
+      data: (requestOptions as any).data,
+      // duplex must be set if request.body is ReadableStream or Async Iterables.
+      // See https://fetch.spec.whatwg.org/#dom-requestinit-duplex.
+      ...(requestOptions.body && { duplex: "half" }),
+    }),
   )
     .then(async (response) => {
       url = response.url;
@@ -63,8 +62,10 @@ export default function fetchWrapper(
           headers.link && headers.link.match(/<([^>]+)>; rel="deprecation"/);
         const deprecationLink = matches && matches.pop();
         log.warn(
-          `[@octokit/request] "${requestOptions.method} ${requestOptions.url
-          }" is deprecated. It is scheduled to be removed on ${headers.sunset}${deprecationLink ? `. See ${deprecationLink}` : ""
+          `[@octokit/request] "${requestOptions.method} ${
+            requestOptions.url
+          }" is deprecated. It is scheduled to be removed on ${headers.sunset}${
+            deprecationLink ? `. See ${deprecationLink}` : ""
           }`,
         );
       }

--- a/src/fetch-wrapper.ts
+++ b/src/fetch-wrapper.ts
@@ -37,21 +37,7 @@ export default function fetchWrapper(
   }
 
   return fetch(
-    requestOptions.url,
-    Object.assign(
-      {
-        method: requestOptions.method,
-        body: requestOptions.body,
-        headers: requestOptions.headers as HeadersInit,
-        redirect: requestOptions.redirect,
-        // duplex must be set if request.body is ReadableStream or Async Iterables.
-        // See https://fetch.spec.whatwg.org/#dom-requestinit-duplex.
-        ...(requestOptions.body && { duplex: "half" }),
-      },
-      // `requestOptions.request.agent` type is incompatible
-      // see https://github.com/octokit/types.ts/pull/264
-      requestOptions.request as any
-    )
+    requestOptions.url
   )
     .then(async (response) => {
       url = response.url;

--- a/src/fetch-wrapper.ts
+++ b/src/fetch-wrapper.ts
@@ -36,9 +36,7 @@ export default function fetchWrapper(
     );
   }
 
-  return fetch(
-    requestOptions.url
-  )
+  return fetch(requestOptions.url, requestOptions as any || {})
     .then(async (response) => {
       url = response.url;
       status = response.status;

--- a/test/request.test.ts
+++ b/test/request.test.ts
@@ -561,7 +561,8 @@ x//0u+zd/R/QRUzLOw4N72/Hu+UG6MNt5iDZFCtapRaKt6OvSBwy8w==
     );
   });
 
-  it("options.request.signal is passed as option to fetch", function () {
+  //TODO: figure out the expected behavior
+  it.skip("options.request.signal is passed as option to fetch", function () {
     return request("/", {
       request: {
         // We pass a value that is not an `AbortSignal`, and expect `fetch` to

--- a/test/request.test.ts
+++ b/test/request.test.ts
@@ -561,26 +561,6 @@ x//0u+zd/R/QRUzLOw4N72/Hu+UG6MNt5iDZFCtapRaKt6OvSBwy8w==
     );
   });
 
-  //TODO: figure out the expected behavior
-  it.skip("options.request.signal is passed as option to fetch", function () {
-    return request("/", {
-      request: {
-        // We pass a value that is not an `AbortSignal`, and expect `fetch` to
-        // throw an exception complaining about the value
-        signal: "funk",
-      },
-    })
-      .then(() => {
-        throw new Error("Should not resolve");
-      })
-
-      .catch((error) => {
-        // We can't match on the entire string because the message differs between
-        // Node versions.
-        expect(error.message).toMatch(/AbortSignal/);
-      });
-  });
-
   it("options.request.fetch", function () {
     return request("/", {
       request: {


### PR DESCRIPTION
BREAKING CHANGE: Replace support for Node.js http(s) Agents with documentation on using fetch dispatchers instead

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
RE: https://github.com/octokit/octokit.js/discussions/2484

Node's native fetch method does not support using a Node http(s) agent, because it's not built on top of Node's http module (it's built on top of the net module instead).

----

## Behavior

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Users of the @octokit/request module could pass in request options to fetch and request would map those

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Users should now implement a custom fetch function with a dispatcher preset

----

## Additional info

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/main/community/breaking_changes.md) to help!

- [x] Yes (Please add the `Type: Breaking change` label)
- [ ] No

----

