### PR TITLE
docs(readme): use 'user-agent' instead of 'agent' as 'header' option in 'Sentible defauls' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,19 +16,20 @@ the passed options and sends the request using [fetch](https://developer.mozilla
 
 <!-- toc -->
 
-- [Features](#features)
-- [Usage](#usage)
-  - [REST API example](#rest-api-example)
-  - [GraphQL example](#graphql-example)
-  - [Alternative: pass `method` & `url` as part of options](#alternative-pass-method--url-as-part-of-options)
-- [Authentication](#authentication)
-- [request()](#request)
-- [`request.defaults()`](#requestdefaults)
-- [`request.endpoint`](#requestendpoint)
-- [Special cases](#special-cases)
-  - [The `data` parameter – set request body directly](#the-data-parameter-%E2%80%93-set-request-body-directly)
-  - [Set parameters for both the URL/query and the request body](#set-parameters-for-both-the-urlquery-and-the-request-body)
-- [LICENSE](#license)
+- [request.js](#requestjs)
+  - [Features](#features)
+  - [Usage](#usage)
+    - [REST API example](#rest-api-example)
+    - [GraphQL example](#graphql-example)
+    - [Alternative: pass `method` \& `url` as part of options](#alternative-pass-method--url-as-part-of-options)
+  - [Authentication](#authentication)
+  - [request()](#request)
+  - [`request.defaults()`](#requestdefaults)
+  - [`request.endpoint`](#requestendpoint)
+  - [Special cases](#special-cases)
+    - [The `data` parameter – set request body directly](#the-data-parameter--set-request-body-directly)
+    - [Set parameters for both the URL/query and the request body](#set-parameters-for-both-the-urlquery-and-the-request-body)
+  - [LICENSE](#license)
 
 <!-- tocstop -->
 
@@ -56,7 +57,7 @@ request("POST /repos/{owner}/{repo}/issues/{number}/labels", {
 
 - `baseUrl`: `https://api.github.com`
 - `headers.accept`: `application/vnd.github.v3+json`
-- `headers.agent`: `octokit-request.js/<current version> <OS information>`, e.g. `octokit-request.js/1.2.3 Node.js/10.15.0 (macOS Mojave; x64)`
+- `headers['user-agent']`: `octokit-request.js/<current version> <OS information>`, e.g. `octokit-request.js/1.2.3 Node.js/10.15.0 (macOS Mojave; x64)`
 
 👌 Simple to test: mock requests by passing a custom fetch method.
 


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->


<!-- Issues are required for both bug fixes and features. -->
No issue for this doc adjustment

----

## Behavior

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->
'Sensible defaults' in `README.md` talks about `headers.agent`

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->
'Sensible defaults' in `README.md` talks about `headers['user-agent']`

----

## Additional info

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/main/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

If `Yes`, what's the impact:

* N/A


### Pull request type
`Type: Documentation`

----

