### PR TITLE
fix: surface 'cause' for undici network errors

### DIFF
--- a/src/fetch-wrapper.ts
+++ b/src/fetch-wrapper.ts
@@ -131,7 +131,20 @@ export default function fetchWrapper(
       if (error instanceof RequestError) throw error;
       else if (error.name === "AbortError") throw error;
 
-      throw new RequestError(error.message, 500, {
+      let message = error.message;
+
+      // undici throws a TypeError for network errors
+      // and puts the error message in `error.cause`
+      // https://github.com/nodejs/undici/blob/e5c9d703e63cd5ad691b8ce26e3f9a81c598f2e3/lib/fetch/index.js#L227
+      if (
+        error instanceof TypeError &&
+        "cause" in error &&
+        typeof error.cause == "string"
+      ) {
+        message = error?.cause ?? message;
+      }
+
+      throw new RequestError(message, 500, {
         request: requestOptions,
       });
     });

--- a/src/fetch-wrapper.ts
+++ b/src/fetch-wrapper.ts
@@ -139,9 +139,9 @@ export default function fetchWrapper(
       if (
         error instanceof TypeError &&
         "cause" in error &&
-        typeof error.cause == "string"
+        typeof error.cause === "string"
       ) {
-        message = error?.cause ?? message;
+        message = error.cause;
       }
 
       throw new RequestError(message, 500, {

--- a/test/request.test.ts
+++ b/test/request.test.ts
@@ -439,6 +439,26 @@ x//0u+zd/R/QRUzLOw4N72/Hu+UG6MNt5iDZFCtapRaKt6OvSBwy8w==
       });
   });
 
+  it("Request TypeError error", () => {
+    const mock = fetchMock.sandbox().get("https://127.0.0.1:8/", {
+      throws: Object.assign(new TypeError("fetch failed"), { cause: "bad" }),
+    });
+
+    // port: 8 // officially unassigned port. See https://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers
+    return request("GET https://127.0.0.1:8/", {
+      request: {
+        fetch: mock,
+      },
+    })
+      .then(() => {
+        throw new Error("should not resolve");
+      })
+      .catch((error) => {
+        expect(error.status).toEqual(500);
+        expect(error.message).toEqual("bad");
+      });
+  });
+
   it("custom user-agent", () => {
     const mock = fetchMock
       .sandbox()


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #641

----

### Before the change?
Network errors from undici are presented with "fetch failed" without showing the underlying cause that undici also presents.

### After the change?
Network errors now correctly propagate the 'cause' from undici

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
- [ ] Yes
- [x] No

----

