### PR TITLE
fix: avoid `Unexpected end of JSON input` when response body is empty

### DIFF
--- a/src/fetch-wrapper.ts
+++ b/src/fetch-wrapper.ts
@@ -153,7 +153,14 @@ export default function fetchWrapper(
 async function getResponseData(response: Response) {
   const contentType = response.headers.get("content-type");
   if (/application\/json/.test(contentType!)) {
-    return response.json();
+    // In the event that we get an empty response body we fallback to
+    // using .text(), but this should be investigated since if this were
+    // to occur in the GitHub API it really should not return an empty body.
+    try {
+      return response.json();
+    } catch (e) {
+      return response.text();
+    }
   }
 
   if (!contentType || /^text\/|charset=utf-8$/.test(contentType)) {

--- a/src/fetch-wrapper.ts
+++ b/src/fetch-wrapper.ts
@@ -153,10 +153,16 @@ export default function fetchWrapper(
 async function getResponseData(response: Response) {
   const contentType = response.headers.get("content-type");
   if (/application\/json/.test(contentType!)) {
-    // In the event that we get an empty response body we fallback to
-    // using .text(), but this should be investigated since if this were
-    // to occur in the GitHub API it really should not return an empty body.
-    return response.json().catch(() => response.text());
+    
+    return response
+      .json()
+      // In the event that we get an empty response body we fallback to
+      // using .text(), but this should be investigated since if this were
+      // to occur in the GitHub API it really should not return an empty body.
+      .catch(() => response.text())
+      // `node-fetch` is throwing a "body used already for" error if `.text()` is run
+      // after a failed .json(). To account for that we fallback to an empty string
+      .catch(() => "");
   }
 
   if (!contentType || /^text\/|charset=utf-8$/.test(contentType)) {

--- a/src/fetch-wrapper.ts
+++ b/src/fetch-wrapper.ts
@@ -153,16 +153,17 @@ export default function fetchWrapper(
 async function getResponseData(response: Response) {
   const contentType = response.headers.get("content-type");
   if (/application\/json/.test(contentType!)) {
-    
-    return response
-      .json()
-      // In the event that we get an empty response body we fallback to
-      // using .text(), but this should be investigated since if this were
-      // to occur in the GitHub API it really should not return an empty body.
-      .catch(() => response.text())
-      // `node-fetch` is throwing a "body used already for" error if `.text()` is run
-      // after a failed .json(). To account for that we fallback to an empty string
-      .catch(() => "");
+    return (
+      response
+        .json()
+        // In the event that we get an empty response body we fallback to
+        // using .text(), but this should be investigated since if this were
+        // to occur in the GitHub API it really should not return an empty body.
+        .catch(() => response.text())
+        // `node-fetch` is throwing a "body used already for" error if `.text()` is run
+        // after a failed .json(). To account for that we fallback to an empty string
+        .catch(() => "")
+    );
   }
 
   if (!contentType || /^text\/|charset=utf-8$/.test(contentType)) {

--- a/src/fetch-wrapper.ts
+++ b/src/fetch-wrapper.ts
@@ -156,11 +156,7 @@ async function getResponseData(response: Response) {
     // In the event that we get an empty response body we fallback to
     // using .text(), but this should be investigated since if this were
     // to occur in the GitHub API it really should not return an empty body.
-    try {
-      return response.json();
-    } catch (e) {
-      return response.text();
-    }
+    return response.json().catch(() => response.text());
   }
 
   if (!contentType || /^text\/|charset=utf-8$/.test(contentType)) {

--- a/test/request.test.ts
+++ b/test/request.test.ts
@@ -400,7 +400,7 @@ x//0u+zd/R/QRUzLOw4N72/Hu+UG6MNt5iDZFCtapRaKt6OvSBwy8w==
     );
   });
 
-  it("response with no body", () => {
+  it("error response with no body (octokit/request.js#649)", () => {
     const mock = fetchMock
       .sandbox()
       .get("path:/repos/octokit-fixture-org/hello-world/contents/README.md", {
@@ -421,8 +421,8 @@ x//0u+zd/R/QRUzLOw4N72/Hu+UG6MNt5iDZFCtapRaKt6OvSBwy8w==
       request: {
         fetch: mock,
       },
-    }).then((response) => {
-      expect(response.data).toEqual("");
+    }).catch((error) => {
+      expect(error.response.data).toEqual("");
     });
   });
 

--- a/test/request.test.ts
+++ b/test/request.test.ts
@@ -400,6 +400,32 @@ x//0u+zd/R/QRUzLOw4N72/Hu+UG6MNt5iDZFCtapRaKt6OvSBwy8w==
     );
   });
 
+  it("response with no body", () => {
+    const mock = fetchMock
+      .sandbox()
+      .get("path:/repos/octokit-fixture-org/hello-world/contents/README.md", {
+        status: 500,
+        body: undefined,
+        headers: {
+          "content-type": "application/json",
+        },
+      });
+
+    return request("GET /repos/{owner}/{repo}/contents/{path}", {
+      headers: {
+        accept: "content-type: application/json",
+      },
+      owner: "octokit-fixture-org",
+      repo: "hello-world",
+      path: "README.md",
+      request: {
+        fetch: mock,
+      },
+    }).then((response) => {
+      expect(response.data).toEqual("");
+    });
+  });
+
   it("non-JSON response", () => {
     const mock = fetchMock
       .sandbox()


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves https://github.com/octokit/request.js/issues/649
----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

*  Customer seems to be having issues with deploying their pages site in GHES and the error via the output from the debug appears to be caused by octokit. Seems when we are getting the response data we might run into an issue where the body is empty and hence we can't parse it using `response.json()` causing the error to be raised.
```
##[debug]Evaluating condition for step: 'Deploy to GitHub Pages'
2##[debug]Evaluating: success()
3##[debug]Evaluating success:
4##[debug]=> true
5##[debug]Result: true
6##[debug]Starting: Deploy to GitHub Pages
7##[debug]Loading inputs
8##[debug]Evaluating: github.token
9##[debug]Evaluating Index:
10##[debug]..Evaluating github:
11##[debug]..=> Object
12##[debug]..Evaluating String:
13##[debug]..=> 'token'
14##[debug]=> '***'
15##[debug]Result: '***'
16##[debug]Loading env
17
Run actions/deploy-pages@v1.2.9
18  with:
19    emit_telemetry: false
20    token: ***
21    timeout: 600000
22    error_count: 10
23    reporting_interval: 5000
24    artifact_name: github-pages
25    preview: false
26##[debug]all variables are set
27##[debug]all variables are set
28##[debug]ID token url is https://gitenterprise.xilinx.com/_services/pipelines/eRhS9LBtNTGin3wENmb093bx6wzbQ19LimyrpKukvyqgYmqa0d/00000000-0000-0000-0000-000000000000/_apis/distributedtask/hubs/Actions/plans/399052e0-ae3b-4207-bd94-d869210658b3/jobs/e07742bd-189a-5079-918b-43f8b2f94b89/idtoken?api-version=2.0
29::add-mask::***
30##[debug]Actor: nilsw
31##[debug]Action ID: deployment
32##[debug]Actions Workflow Run ID: 98423
33##[debug]all variables are set
34Artifact exchange URL: https://gitenterprise.xilinx.com/_services/pipelines/eRhS9LBtNTGin3wENmb093bx6wzbQ19LimyrpKukvyqgYmqa0d/_apis/pipelines/workflows/98423/artifacts?api-version=6.0-preview
35##[debug]{"count":1,"value":[{"containerId":240179,"size":10240,"signedContent":null,"fileContainerResourceUrl":"https://gitenterprise.xilinx.com/_services/pipelines/eRhS9LBtNTGin3wENmb093bx6wzbQ19LimyrpKukvyqgYmqa0d/_apis/resources/Containers/240179","type":"actions_storage","name":"github-pages","url":"https://gitenterprise.xilinx.com/_services/pipelines/eRhS9LBtNTGin3wENmb093bx6wzbQ19LimyrpKukvyqgYmqa0d/_apis/pipelines/1/runs/4/artifacts?artifactName=github-pages","expiresOn":"2023-10-26T19:25:29.6207174Z","items":null}]}
36Creating Pages deployment with payload:
37{
38 "artifact_url": "https://gitenterprise.xilinx.com/_services/pipelines/eRhS9LBtNTGin3wENmb093bx6wzbQ19LimyrpKukvyqgYmqa0d/_apis/pipelines/1/runs/4/artifacts?artifactName=github-pages&%24expand=SignedContent",
39 "pages_build_version": "0fbfbe3039ef54252a8d6af01dec3d3020463a67",
40 "oidc_token": "***"
41}
42
Error:
Creating Pages deployment failed
43
Error:
HttpError: invalid json response body at https://gitenterprise.xilinx.com/api/v3/repos/security/sfdb-debug/pages/deployment reason: Unexpected end of JSON input
44    at /scratch/ghe-runners/2/_work/_actions/actions/deploy-pages/v1.2.9/webpack:/deploy-pages/node_modules/@octokit/request/dist-node/index.js:108:1
45    at processTicksAndRejections (node:internal/process/task_queues:96:5)
46    at createPagesDeployment (/scratch/ghe-runners/2/_work/_actions/actions/deploy-pages/v1.2.9/webpack:/deploy-pages/src/api-client.js:116:1)
47    at Deployment.create (/scratch/ghe-runners/2/_work/_actions/actions/deploy-pages/v1.2.9/webpack:/deploy-pages/src/deployment.js:59:1)
48    at main (/scratch/ghe-runners/2/_work/_actions/actions/deploy-pages/v1.2.9/webpack:/deploy-pages/src/index.js:30:1)
49
Error:
HttpError: invalid json response body at https://gitenterprise.xilinx.com/api/v3/repos/security/sfdb-debug/pages/deployment reason: Unexpected end of JSON input
50##[debug]Node Action run completed with exit code 1
51##[debug]Finishing: Deploy to GitHub Pages
```

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Currently, wrapped the response in a try catch block. If we fail to parse the response to json we fall back to text and hence we are able to return an empty body as opposed to raising an error. However, we might need to investigate what is causing this as the GitHub API should not return an empty body. 

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [ ] No

----

