### PR TITLE
fix: integrate isPlainObject

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@octokit/endpoint": "^9.0.0",
         "@octokit/request-error": "^5.0.0",
         "@octokit/types": "^12.0.0",
-        "is-plain-object": "^5.0.0",
         "universal-user-agent": "^6.0.0"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "@octokit/endpoint": "^9.0.0",
     "@octokit/request-error": "^5.0.0",
     "@octokit/types": "^12.0.0",
-    "is-plain-object": "^5.0.0",
     "universal-user-agent": "^6.0.0"
   },
   "devDependencies": {

--- a/src/fetch-wrapper.ts
+++ b/src/fetch-wrapper.ts
@@ -1,4 +1,4 @@
-import { isPlainObject } from "is-plain-object";
+import { isPlainObject } from "./is-plain-object";
 import { RequestError } from "@octokit/request-error";
 import type { EndpointInterface } from "@octokit/types";
 

--- a/src/is-plain-object.ts
+++ b/src/is-plain-object.ts
@@ -1,0 +1,17 @@
+export function isPlainObject(value: unknown): value is Object {
+  if (typeof value !== "object" || value === null) return false;
+
+  if (Object.prototype.toString.call(value) !== "[object Object]") return false;
+
+  const proto = Object.getPrototypeOf(value);
+  if (proto === null) return true;
+
+  const Ctor =
+    Object.prototype.hasOwnProperty.call(proto, "constructor") &&
+    proto.constructor;
+  return (
+    typeof Ctor === "function" &&
+    Ctor instanceof Ctor &&
+    Function.prototype.call(Ctor) === Function.prototype.call(value)
+  );
+}

--- a/test/is-plain-object.test.ts
+++ b/test/is-plain-object.test.ts
@@ -1,0 +1,31 @@
+import { isPlainObject } from "../src/is-plain-object";
+
+describe("isPlainObject", () => {
+  function Foo() {
+    // @ts-ignore
+    this.a = 1;
+  }
+
+  it("isPlainObject(NaN)", () => {
+    expect(isPlainObject(NaN)).toBe(false);
+  });
+  it("isPlainObject([1, 2, 3])", () => {
+    expect(isPlainObject([1, 2, 3])).toBe(false);
+  });
+  it("isPlainObject(null)", () => {
+    expect(isPlainObject(null)).toBe(false);
+  });
+  it("isPlainObject({ 'x': 0, 'y': 0 })", () => {
+    expect(isPlainObject({ x: 0, y: 0 })).toBe(true);
+  });
+  it("isPlainObject(Object.create(null))", () => {
+    expect(isPlainObject(Object.create(null))).toBe(true);
+  });
+  it("isPlainObject(Object.create(new Foo()))", () => {
+    // @ts-ignore
+    expect(isPlainObject(Object.create(new Foo()))).toBe(false);
+  });
+  it("isPlainObject(Object.create(new Date()))", () => {
+    expect(isPlainObject(Object.create(new Date()))).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes https://github.com/octokit/core.js/issues/519

See also https://github.com/you-dont-need/You-Dont-Need-Lodash-Underscore#_isplainobject
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #ISSUE_NUMBER

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* 

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* 

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

