### PR TITLE
refactor: use `node:` specifier imports and full relative paths imports, update tests for new type errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@types/node": "^20.0.0",
         "@types/once": "^1.4.0",
         "esbuild": "^0.19.0",
-        "fetch-mock": "^9.3.1",
+        "fetch-mock": "npm:@gr2m/fetch-mock@^9.11.0-pull-request-644.1",
         "glob": "^10.2.4",
         "jest": "^29.0.0",
         "lolex": "^6.0.0",
@@ -2957,9 +2957,10 @@
       }
     },
     "node_modules/fetch-mock": {
-      "version": "9.11.0",
-      "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-9.11.0.tgz",
-      "integrity": "sha512-PG1XUv+x7iag5p/iNHD4/jdpxL9FtVSqRMUQhPab4hVDt80T1MH5ehzVrL2IdXO9Q2iBggArFvPqjUbHFuI58Q==",
+      "name": "@gr2m/fetch-mock",
+      "version": "9.11.0-pull-request-644.1",
+      "resolved": "https://registry.npmjs.org/@gr2m/fetch-mock/-/fetch-mock-9.11.0-pull-request-644.1.tgz",
+      "integrity": "sha512-gTp6RCHzlOXS1qRb0APfuyz48Lw/JFPa4uiar+kEgL1STsDwth75HJZ4x30tBlXMJXV8XDTDzJ2Hz9w3RWiHJA==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@types/node": "^20.0.0",
     "@types/once": "^1.4.0",
     "esbuild": "^0.19.0",
-    "fetch-mock": "^9.3.1",
+    "fetch-mock": "npm:@gr2m/fetch-mock@^9.11.0-pull-request-644.1",
     "glob": "^10.2.4",
     "jest": "^29.0.0",
     "lolex": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,10 @@
     },
     "modulePathIgnorePatterns": [
       "<rootDir>/pkg"
-    ]
+    ],
+    "moduleNameMapper": {
+      "^(.+)\\.jsx?$": "$1"
+    }
   },
   "release": {
     "branches": [

--- a/src/fetch-wrapper.ts
+++ b/src/fetch-wrapper.ts
@@ -1,8 +1,8 @@
-import { isPlainObject } from "./is-plain-object";
+import { isPlainObject } from "./is-plain-object.js";
 import { RequestError } from "@octokit/request-error";
 import type { EndpointInterface } from "@octokit/types";
 
-import getBuffer from "./get-buffer-response";
+import getBuffer from "./get-buffer-response.js";
 
 export default function fetchWrapper(
   requestOptions: ReturnType<EndpointInterface>,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
 import { endpoint } from "@octokit/endpoint";
 import { getUserAgent } from "universal-user-agent";
 
-import { VERSION } from "./version";
-import withDefaults from "./with-defaults";
+import { VERSION } from "./version.js";
+import withDefaults from "./with-defaults.js";
 
 export const request = withDefaults(endpoint, {
   headers: {

--- a/src/with-defaults.ts
+++ b/src/with-defaults.ts
@@ -1,4 +1,4 @@
-import fetchWrapper from "./fetch-wrapper";
+import fetchWrapper from "./fetch-wrapper.js";
 import type {
   EndpointOptions,
   EndpointInterface,

--- a/test/defaults.test.ts
+++ b/test/defaults.test.ts
@@ -1,6 +1,6 @@
 import fetchMock from "fetch-mock";
 
-import { request } from "../src";
+import { request } from "../src/index.ts";
 
 describe("endpoint.defaults()", () => {
   it("is a function", () => {

--- a/test/is-plain-object.test.ts
+++ b/test/is-plain-object.test.ts
@@ -1,4 +1,4 @@
-import { isPlainObject } from "../src/is-plain-object";
+import { isPlainObject } from "../src/is-plain-object.ts";
 
 describe("isPlainObject", () => {
   function Foo() {

--- a/test/request.test.ts
+++ b/test/request.test.ts
@@ -1,5 +1,5 @@
-import fs from "fs";
-import stream, { Stream } from "stream";
+import fs from "node:fs";
+import stream, { Stream } from "node:stream";
 
 import { getUserAgent } from "universal-user-agent";
 import fetchMock from "fetch-mock";

--- a/test/request.test.ts
+++ b/test/request.test.ts
@@ -11,7 +11,7 @@ import type {
   ResponseHeaders,
 } from "@octokit/types";
 
-import { request } from "../src";
+import { request } from "../src/index.ts";
 
 const userAgent = `octokit-request.js/0.0.0-development ${getUserAgent()}`;
 const stringToArrayBuffer = require("string-to-arraybuffer");

--- a/test/request.test.ts
+++ b/test/request.test.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
-import stream, { Stream } from "node:stream";
+import stream from "node:stream";
+import { ReadableStream } from "node:stream/web";
 
 import { getUserAgent } from "universal-user-agent";
 import fetchMock from "fetch-mock";
@@ -1116,7 +1117,7 @@ x//0u+zd/R/QRUzLOw4N72/Hu+UG6MNt5iDZFCtapRaKt6OvSBwy8w==
     }).then((response) => {
       expect(response.status).toEqual(200);
       expect(response.headers["content-type"]).toEqual("application/x-gzip");
-      expect(response.data).toBeInstanceOf(Stream);
+      expect(response.data).toBeInstanceOf(ReadableStream);
       expect(mock.done()).toBe(true);
     });
   });

--- a/test/tsconfig.test.json
+++ b/test/tsconfig.test.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "emitDeclarationOnly": false,
     "noEmit": true,
-    "verbatimModuleSyntax": false
+    "verbatimModuleSyntax": false,
+    "allowImportingTsExtensions": true
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
This PR replaces NodeJS internal module imports with `node:` specifier imports.