### PR TITLE
ci(workflows): enable prettier for forks

### DIFF
--- a/.github/workflows/update-prettier.yml
+++ b/.github/workflows/update-prettier.yml
@@ -4,23 +4,48 @@ name: Update Prettier
     branches:
       - renovate/prettier-*
 
-permissions:
-  contents: read
-
 jobs:
   update_prettier:
+    if: github.repository_owner == 'octokit'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
           cache: npm
       - run: npm ci
       - run: npm run lint:fix
       - uses: gr2m/create-or-update-pull-request-action@v1.x
         env:
           GITHUB_TOKEN: ${{ secrets.OCTOKITBOT_PAT }}
+        with:
+          title: Prettier updated
+          body: An update to prettier required updates to your code.
+          branch: ${{ github.ref }}
+          commit-message: "style: prettier"
+
+  update_prettier_fork:
+    if: github.repository_owner != 'octokit'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run lint:fix
+      - uses: gr2m/create-or-update-pull-request-action@v1.x
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         with:
           title: Prettier updated
           body: An update to prettier required updates to your code.


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #674

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* > Error: GITHUB_TOKEN is not configured. Make sure you made it available to your action

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Prettier works in forks (and could work in this repository)

Note: The configuration has a PAT... There are a whole bunch of ways to make this work, but this seems simplest... One could just remove the PAT, or I could add some really complicated code to check to see if there is a PAT and if there is a PAT do one thing and then if not, do the other... But, I don't see the point.

I'm also upgrading the node version to 20 since this package.json is `20` and it seems like a bad idea to run linters w/ the wrong version of node -- the prettier workflow is disabled in this repository and I wonder if that's one of the reasons it is...

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

