### PR TITLE
test: remove `AbortController` and `AbortSignal` polyfills

### DIFF
--- a/test/request.test.ts
+++ b/test/request.test.ts
@@ -1046,25 +1046,6 @@ x//0u+zd/R/QRUzLOw4N72/Hu+UG6MNt5iDZFCtapRaKt6OvSBwy8w==
   });
 
   it("bubbles up AbortError if the request is aborted", () => {
-    // AbortSignal and AbortController do not exist on
-    // Node < 15. The main parts of their API have been
-    // reproduced in the mocks below.
-    class AbortSignal {
-      abort = () => {
-        const e = new Error("");
-        e.name = "AbortError";
-        throw e;
-      };
-
-      addEventListener = () => {};
-    }
-
-    class AbortController {
-      abort = () => {
-        this.signal.abort();
-      };
-      signal = new AbortSignal();
-    }
     const abortController = new AbortController();
     const mock = fetchMock.sandbox().post(
       "https://api.github.com/repos/octokit-fixture-org/release-assets/releases/tags/v1.0.0",


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #ISSUE_NUMBER

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Polyfills meant for older versions of Node were present

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Removes those unneeded polyfills

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

