### PR TITLE
ci(release): remove duplicate permissions entry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,10 +7,6 @@ name: Release
       - beta
       - "*.x"
 
-permissions:
-  contents: write
-  issues: write
-
 # These are recommended by the semantic-release docs: https://github.com/semantic-release/npm#npm-provenance
 permissions:
     contents: write # to be able to publish a GitHub release


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #ISSUE_NUMBER

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* While introducing provenance to this repo in #685, the `permissions` key in the workflow was duplicated

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Removes the duplicated permissions key

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [ ] No

----

