### PR TITLE
refactor: assign fetch once

### DIFF
--- a/src/fetch-wrapper.ts
+++ b/src/fetch-wrapper.ts
@@ -25,10 +25,8 @@ export default function fetchWrapper(
   let status: number;
   let url: string;
 
-  let { fetch } = globalThis;
-  if (requestOptions.request?.fetch) {
-    fetch = requestOptions.request.fetch;
-  }
+  const fetch: typeof globalThis.fetch =
+    requestOptions.request?.fetch || globalThis.fetch;
 
   if (!fetch) {
     throw new Error(


### PR DESCRIPTION
We can assign directly fetch once. Probably we originally did this this way to keep the type of fetch. But this simplifies the code.

I will provide multiple PRs for this package, to avoid a big convoluted PR with various changes.

Also creating them as chores, to avoid releasing a new version every time it would be merged.