### PR TITLE
Correctly parse response bodies as JSON where the Content-Type is `application/scim+json`

### DIFF
--- a/src/fetch-wrapper.ts
+++ b/src/fetch-wrapper.ts
@@ -3,6 +3,8 @@ import { isPlainObject } from "./is-plain-object.js";
 import { RequestError } from "@octokit/request-error";
 import type { EndpointInterface, OctokitResponse } from "@octokit/types";
 
+type ContentType = ReturnType<typeof safeParse>;
+
 export default async function fetchWrapper(
   requestOptions: ReturnType<EndpointInterface>,
 ): Promise<OctokitResponse<any>> {
@@ -173,7 +175,7 @@ async function getResponseData(response: Response): Promise<any> {
   }
 }
 
-function isJSONResponse(mimetype: { type: string }): boolean {
+function isJSONResponse(mimetype: ContentType): boolean {
   return (
     mimetype.type === "application/json" ||
     mimetype.type === "application/scim+json"

--- a/src/fetch-wrapper.ts
+++ b/src/fetch-wrapper.ts
@@ -174,7 +174,10 @@ async function getResponseData(response: Response): Promise<any> {
 }
 
 function isJSONResponse(mimetype: { type: string }) {
-  return mimetype.type === "application/json" || mimetype.type === "application/scim+json";
+  return (
+    mimetype.type === "application/json" ||
+    mimetype.type === "application/scim+json"
+  );
 }
 
 function toErrorMessage(data: string | ArrayBuffer | Record<string, unknown>) {

--- a/src/fetch-wrapper.ts
+++ b/src/fetch-wrapper.ts
@@ -155,7 +155,7 @@ async function getResponseData(response: Response): Promise<any> {
 
   const mimetype = safeParse(contentType);
 
-  if (mimetype.type === "application/json") {
+  if (isJSONResponse(mimetype)) {
     let text = "";
     try {
       text = await response.text();
@@ -171,6 +171,10 @@ async function getResponseData(response: Response): Promise<any> {
   } else {
     return response.arrayBuffer().catch(() => new ArrayBuffer(0));
   }
+}
+
+function isJSONResponse(mimetype: { type: string }) {
+  return mimetype.type === "application/json" || mimetype.type === "application/scim+json";
 }
 
 function toErrorMessage(data: string | ArrayBuffer | Record<string, unknown>) {

--- a/src/fetch-wrapper.ts
+++ b/src/fetch-wrapper.ts
@@ -173,7 +173,7 @@ async function getResponseData(response: Response): Promise<any> {
   }
 }
 
-function isJSONResponse(mimetype: { type: string }) {
+function isJSONResponse(mimetype: { type: string }): boolean {
   return (
     mimetype.type === "application/json" ||
     mimetype.type === "application/scim+json"

--- a/test/request.test.ts
+++ b/test/request.test.ts
@@ -869,7 +869,7 @@ x//0u+zd/R/QRUzLOw4N72/Hu+UG6MNt5iDZFCtapRaKt6OvSBwy8w==
         required_pull_request_reviews: {
           required_approving_review_count: 1,
           dismiss_stale_reviews: true,
-          require_code owner_reviews: true,
+          require_code_owner_reviews: true,
           dismissal_restrictions: { users: [], teams: [] },
         },
         restrictions: { users: [], teams: [] },

--- a/test/request.test.ts
+++ b/test/request.test.ts
@@ -869,7 +869,7 @@ x//0u+zd/R/QRUzLOw4N72/Hu+UG6MNt5iDZFCtapRaKt6OvSBwy8w==
         required_pull_request_reviews: {
           required_approving_review_count: 1,
           dismiss_stale_reviews: true,
-          require_code_owner_reviews: true,
+          require_code owner_reviews: true,
           dismissal_restrictions: { users: [], teams: [] },
         },
         restrictions: { users: [], teams: [] },
@@ -1262,5 +1262,42 @@ x//0u+zd/R/QRUzLOw4N72/Hu+UG6MNt5iDZFCtapRaKt6OvSBwy8w==
         },
       }),
     ).rejects.toHaveProperty("message", "Unknown error: {}");
+  });
+
+  it("parses response bodies as JSON when Content-Type is application/scim+json", async () => {
+    expect.assertions(1);
+
+    const mock = fetchMock.createInstance();
+    mock.get("https://api.github.com/scim/v2/Users", {
+      status: 200,
+      body: {
+        totalResults: 1,
+        Resources: [
+          {
+            id: "123",
+            userName: "octocat",
+          },
+        ],
+      },
+      headers: {
+        "Content-Type": "application/scim+json",
+      },
+    });
+
+    const response = await request("GET /scim/v2/Users", {
+      request: {
+        fetch: mock.fetchHandler,
+      },
+    });
+
+    expect(response.data).toEqual({
+      totalResults: 1,
+      Resources: [
+        {
+          id: "123",
+          userName: "octocat",
+        },
+      ],
+    });
   });
 });


### PR DESCRIPTION
GitHub has APIs that return `application/scim+json` response bodies. Currently, these responses are not parsed as JSON, and instead, an `ArrayBuffer` is returned in `response.data`.

This adds handling for `application/scim+json` so they are parsed as JSON as normal.

## Minimal reproduction

```js
import { Octokit } from "@octokit/rest";
import { enterpriseCloud } from "@octokit/plugin-enterprise-cloud";

const MyOctokit = Octokit.plugin(enterpriseCloud);
const myOctokit = new MyOctokit({
  auth: "ghp_xxxxxxxx",
});

const resp = await myOctokit.request('GET /scim/v2/enterprises/{enterprise}/Groups', {
  enterprise: 'fabrikam'
});
console.log(JSON.stringify(resp.data));
```

## Detailed changes

* Modify `getResponseData` function in `src/fetch-wrapper.ts` to include a check for `application/scim+json` content type.
* Refactor content type check into a new `isJSONResponse` function.
* Add a test in `test/request.test.ts` to verify that response bodies with `application/scim+json` content type are correctly parsed as JSON.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/octokit/request.js/pull/731?shareId=b954401a-4f12-40b8-828b-0a0253460f71).