### PR TITLE
fix(pkg): unreplaced version number in `dist-bundle/`

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,8 +69,7 @@
         "semantic-release-plugin-update-version-in-files",
         {
           "files": [
-            "pkg/dist-web/*",
-            "pkg/dist-node/*",
+            "pkg/dist-bundle/*",
             "pkg/*/version.*"
           ]
         }


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #764

Please note that since I don't have write access to this package on npm registry, `npx semantic-release --dry-run` [refused](https://semantic-release.gitbook.io/semantic-release/usage/configuration#dryrun) to continue processing. So the fix is NOT fully tested.

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Got `var VERSION = "0.0.0-development";` in `dist-bundle/index.js`

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* `0.0.0-development` should be replaced with the actual version number

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

