### PR TITLE
fix(security): mitigate potential ReDoS in deprecation link regex (6.x)

### DIFF
--- a/src/fetch-wrapper.ts
+++ b/src/fetch-wrapper.ts
@@ -58,7 +58,7 @@ export default function fetchWrapper(
 
       if ("deprecation" in headers) {
         const matches =
-          headers.link && headers.link.match(/<([^>]+)>; rel="deprecation"/);
+          headers.link && headers.link.match(/<([^<>]+)>; rel="deprecation"/);
         const deprecationLink = matches && matches.pop();
         log.warn(
           `[@octokit/request] "${requestOptions.method} ${


### PR DESCRIPTION
The deprecation link regex in 6.x is still using a loose pattern that allows for excessive backtracking. Swapping it for the more restrictive logic used in current versions to prevent potential perf hits under load.