### PR TITLE
fix: use `json-with-bigint` instead of built-in JSON methods in order to properly support int64's

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-development",
       "license": "MIT",
       "dependencies": {
-        "@octokit/endpoint": "^11.0.2",
+        "@octokit/endpoint": "^11.0.3",
         "@octokit/request-error": "^7.0.2",
         "@octokit/types": "^16.0.0",
         "fast-content-type-parse": "^3.0.0",
@@ -732,9 +732,9 @@
       }
     },
     "node_modules/@octokit/endpoint": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.2.tgz",
-      "integrity": "sha512-4zCpzP1fWc7QlqunZ5bSEjxc6yLAlRTnDwKtgXfcI/FxxGoqedDG8V2+xJ60bV2kODqcGB+nATdtap/XYq2NZQ==",
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.3.tgz",
+      "integrity": "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==",
       "license": "MIT",
       "dependencies": {
         "@octokit/types": "^16.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@octokit/request-error": "^7.0.2",
         "@octokit/types": "^16.0.0",
         "fast-content-type-parse": "^3.0.0",
+        "json-with-bigint": "^3.5.3",
         "universal-user-agent": "^7.0.2"
       },
       "devDependencies": {
@@ -1871,6 +1872,12 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-with-bigint": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.3.tgz",
+      "integrity": "sha512-QObKu6nxy7NsxqR0VK4rkXnsNr5L9ElJaGEg+ucJ6J7/suoKZ0n+p76cu9aCqowytxEbwYNzvrMerfMkXneF5A==",
       "license": "MIT"
     },
     "node_modules/lru-cache": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@octokit/request-error": "^7.0.2",
     "@octokit/types": "^16.0.0",
     "fast-content-type-parse": "^3.0.0",
+    "json-with-bigint": "^3.5.3",
     "universal-user-agent": "^7.0.2"
   },
   "devDependencies": {
@@ -38,9 +39,9 @@
     "@vitest/coverage-v8": "^4.0.0",
     "esbuild": "^0.27.0",
     "fetch-mock": "^12.0.0",
-    "tinyglobby": "^0.2.15",
     "prettier": "3.6.2",
     "semantic-release-plugin-update-version-in-files": "^2.0.0",
+    "tinyglobby": "^0.2.15",
     "typescript": "^5.0.0",
     "undici": "^7.0.0",
     "vitest": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "author": "Gregor Martynus (https://github.com/gr2m)",
   "license": "MIT",
   "dependencies": {
-    "@octokit/endpoint": "^11.0.2",
+    "@octokit/endpoint": "^11.0.3",
     "@octokit/request-error": "^7.0.2",
     "@octokit/types": "^16.0.0",
     "fast-content-type-parse": "^3.0.0",

--- a/src/fetch-wrapper.ts
+++ b/src/fetch-wrapper.ts
@@ -164,12 +164,10 @@ async function getResponseData(response: Response): Promise<any> {
   const mimetype = safeParse(contentType);
 
   if (isJSONResponse(mimetype)) {
-    let text = "";
     try {
-      text = await response.text();
-      return JSON.parse(text);
+      return await response.json();
     } catch (err) {
-      return text;
+      return "";
     }
   } else if (
     mimetype.type.startsWith("text/") ||

--- a/src/fetch-wrapper.ts
+++ b/src/fetch-wrapper.ts
@@ -164,7 +164,10 @@ async function getResponseData(response: Response): Promise<any> {
   const mimetype = safeParse(contentType);
 
   if (isJSONResponse(mimetype)) {
+    let text = ""
     try {
+      text = await request.text();
+      JSON.parse(text);
       return await response.json();
     } catch (err) {
       return "";

--- a/src/fetch-wrapper.ts
+++ b/src/fetch-wrapper.ts
@@ -1,4 +1,5 @@
 import { safeParse } from "fast-content-type-parse";
+import { JSONParse } from "json-with-bigint";
 import { isPlainObject } from "./is-plain-object.js";
 import { RequestError } from "@octokit/request-error";
 import type { EndpointInterface, OctokitResponse } from "@octokit/types";
@@ -167,8 +168,7 @@ async function getResponseData(response: Response): Promise<any> {
     let text = "";
     try {
       text = await response.text();
-      JSON.parse(text);
-      return await response.json();
+      return JSONParse(text);
     } catch (err) {
       return text;
     }

--- a/src/fetch-wrapper.ts
+++ b/src/fetch-wrapper.ts
@@ -166,7 +166,7 @@ async function getResponseData(response: Response): Promise<any> {
   if (isJSONResponse(mimetype)) {
     let text = ""
     try {
-      text = await request.text();
+      text = await response.text();
       JSON.parse(text);
       return await response.json();
     } catch (err) {

--- a/src/fetch-wrapper.ts
+++ b/src/fetch-wrapper.ts
@@ -164,13 +164,13 @@ async function getResponseData(response: Response): Promise<any> {
   const mimetype = safeParse(contentType);
 
   if (isJSONResponse(mimetype)) {
-    let text = ""
+    let text = "";
     try {
       text = await response.text();
       JSON.parse(text);
       return await response.json();
     } catch (err) {
-      return "";
+      return text;
     }
   } else if (
     mimetype.type.startsWith("text/") ||

--- a/src/fetch-wrapper.ts
+++ b/src/fetch-wrapper.ts
@@ -1,5 +1,5 @@
 import { safeParse } from "fast-content-type-parse";
-import { JSONParse } from "json-with-bigint";
+import { JSONParse, JSONStringify } from "json-with-bigint";
 import { isPlainObject } from "./is-plain-object.js";
 import { RequestError } from "@octokit/request-error";
 import type { EndpointInterface, OctokitResponse } from "@octokit/types";
@@ -27,7 +27,7 @@ export default async function fetchWrapper(
 
   const body =
     isPlainObject(requestOptions.body) || Array.isArray(requestOptions.body)
-      ? JSON.stringify(requestOptions.body)
+      ? JSONStringify(requestOptions.body)
       : requestOptions.body;
 
   // Header values must be `string`

--- a/test/request.test.ts
+++ b/test/request.test.ts
@@ -14,6 +14,7 @@ import type {
 } from "@octokit/types";
 
 import { request } from "../src/index.ts";
+import { JSONStringify } from "json-with-bigint";
 
 const userAgent = `octokit-request.js/0.0.0-development ${getUserAgent()}`;
 const __filename = new URL(import.meta.url);
@@ -1364,5 +1365,32 @@ x//0u+zd/R/QRUzLOw4N72/Hu+UG6MNt5iDZFCtapRaKt6OvSBwy8w==
 
     expect(response.status).toEqual(200);
     expect(response.data[0].id).toEqual(BigInt(Number.MAX_SAFE_INTEGER) + 9n);
+  });
+
+  it("properly serialises request bodies that contain int64 (BigInt)", async () => {
+    expect.assertions(2);
+
+    const id = BigInt(Number.MAX_SAFE_INTEGER) + 9n;
+    const mock = fetchMock.createInstance();
+    mock.get("https://api.github.com/app/hook/deliveries", {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json; charset=utf-8",
+      },
+      body: JSONStringify({
+        id: id,
+      }),
+    });
+
+    const response = await request("GET /app/hook/deliveries/{delivery_id}", {
+      // @ts-expect-error The types won't allw BigInt until https://github.com/octokit/openapi-types.ts/pull/489 is merged and released
+      delivery_id: id,
+      request: {
+        fetch: mock.fetchHandler,
+      },
+    });
+
+    expect(response.status).toEqual(200);
+    expect(response.data.id).toEqual(id);
   });
 });

--- a/test/request.test.ts
+++ b/test/request.test.ts
@@ -1328,4 +1328,41 @@ x//0u+zd/R/QRUzLOw4N72/Hu+UG6MNt5iDZFCtapRaKt6OvSBwy8w==
       ],
     });
   });
+
+  it("parses JSON response bodies that contain int64 (BigInt)", async () => {
+    expect.assertions(2);
+
+    const mock = fetchMock.createInstance();
+    mock.get("https://api.github.com/app/hook/deliveries", {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json; charset=utf-8",
+      },
+      body: [
+        {
+          id: Number.MAX_SAFE_INTEGER + 9,
+          guid: "0b989ba4-242f-11e5-81e1-c7b6966d2516",
+          delivered_at: "2019-06-03T00:57:16Z",
+          redelivery: false,
+          duration: 0.27,
+          status: "OK",
+          status_code: 200,
+          event: "issues",
+          action: "opened",
+          installation_id: 123,
+          repository_id: 456,
+          throttled_at: "2019-06-03T00:57:16Z",
+        },
+      ],
+    });
+
+    const response = await request("GET /app/hook/deliveries", {
+      request: {
+        fetch: mock.fetchHandler,
+      },
+    });
+
+    expect(response.status).toEqual(200);
+    expect(response.data[0].id).toEqual(BigInt(Number.MAX_SAFE_INTEGER) + 9n);
+  });
 });

--- a/test/request.test.ts
+++ b/test/request.test.ts
@@ -1366,31 +1366,4 @@ x//0u+zd/R/QRUzLOw4N72/Hu+UG6MNt5iDZFCtapRaKt6OvSBwy8w==
     expect(response.status).toEqual(200);
     expect(response.data[0].id).toEqual(BigInt(Number.MAX_SAFE_INTEGER) + 9n);
   });
-
-  it("properly serialises request bodies that contain int64 (BigInt)", async () => {
-    expect.assertions(2);
-
-    const id = BigInt(Number.MAX_SAFE_INTEGER) + 9n;
-    const mock = fetchMock.createInstance();
-    mock.get("https://api.github.com/app/hook/deliveries", {
-      status: 200,
-      headers: {
-        "Content-Type": "application/json; charset=utf-8",
-      },
-      body: JSONStringify({
-        id: id,
-      }),
-    });
-
-    const response = await request("GET /app/hook/deliveries/{delivery_id}", {
-      // @ts-expect-error The types won't allw BigInt until https://github.com/octokit/openapi-types.ts/pull/489 is merged and released
-      delivery_id: id,
-      request: {
-        fetch: mock.fetchHandler,
-      },
-    });
-
-    expect(response.status).toEqual(200);
-    expect(response.data.id).toEqual(id);
-  });
 });


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #797 

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Used `JSON.parse()` and `JSON.stringify()` which cannot handle BigInt

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Use the `json-with-bigint` package

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

