### PR TITLE
Use "content-type" for parsing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@octokit/endpoint": "^11.0.3",
         "@octokit/request-error": "^7.0.2",
         "@octokit/types": "^16.0.0",
+        "content-type": "^2.0.0",
         "fast-content-type-parse": "^3.0.0",
         "json-with-bigint": "^3.5.3",
         "universal-user-agent": "^7.0.2"
@@ -1515,6 +1516,19 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@octokit/endpoint": "^11.0.3",
     "@octokit/request-error": "^7.0.2",
     "@octokit/types": "^16.0.0",
+    "content-type": "^2.0.0",
     "fast-content-type-parse": "^3.0.0",
     "json-with-bigint": "^3.5.3",
     "universal-user-agent": "^7.0.2"

--- a/src/fetch-wrapper.ts
+++ b/src/fetch-wrapper.ts
@@ -1,10 +1,8 @@
-import { safeParse } from "fast-content-type-parse";
+import { parse, type ContentType } from "content-type";
 import { JSONParse, JSONStringify } from "json-with-bigint";
 import { isPlainObject } from "./is-plain-object.js";
 import { RequestError } from "@octokit/request-error";
 import type { EndpointInterface, OctokitResponse } from "@octokit/types";
-
-type ContentType = ReturnType<typeof safeParse>;
 
 /* v8 ignore next -- @preserve */
 const noop = () => "";
@@ -162,7 +160,7 @@ async function getResponseData(response: Response): Promise<any> {
     return response.text().catch(noop);
   }
 
-  const mimetype = safeParse(contentType);
+  const mimetype = parse(contentType);
 
   if (isJSONResponse(mimetype)) {
     let text = "";


### PR DESCRIPTION
Apologies for opening a PR without a related issue. Feel free to close if you prefer to discuss the change in an issue first.

This package is one of a small handful using `fast-content-type-parse`, a fork of `content-type`. Since it's the most popular dependent, I figured I should open a PR to bring `content-type` back to your attention.

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* `fast-content-type-parse` was used to parse

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Use `content-type` to parse

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----


Running the `fast-content-type-parse` performance benchmark with `content-type@2` installed:

```
Benchmarking: "application/json; charset="utf-8""
util#MIMEType x 4,476,603 ops/sec ±2.85% (93 runs sampled)
fast-content-type-parse#parse x 4,891,585 ops/sec ±0.87% (94 runs sampled)
fast-content-type-parse#safeParse x 4,919,872 ops/sec ±0.40% (99 runs sampled)
content-type#parse x 7,153,657 ops/sec ±0.24% (95 runs sampled)
busboy#parseContentType x 1,050,032 ops/sec ±0.97% (97 runs sampled)
Fastest is content-type#parse
```

In `content-type@2` it focused on a lenient and fast parser which aligns with you already using `safeParse`, so no changes are necessary aside from the dependency change.