### PR TITLE
fix: remove unused fast-content-type-parse dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@octokit/request-error": "^7.0.2",
         "@octokit/types": "^16.0.0",
         "content-type": "^2.0.0",
-        "fast-content-type-parse": "^3.0.0",
         "json-with-bigint": "^3.5.3",
         "universal-user-agent": "^7.0.2"
       },
@@ -1655,22 +1654,6 @@
       "engines": {
         "node": ">=12.0.0"
       }
-    },
-    "node_modules/fast-content-type-parse": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-3.0.0.tgz",
-      "integrity": "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/fdir": {
       "version": "6.5.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "@octokit/request-error": "^7.0.2",
     "@octokit/types": "^16.0.0",
     "content-type": "^2.0.0",
-    "fast-content-type-parse": "^3.0.0",
     "json-with-bigint": "^3.5.3",
     "universal-user-agent": "^7.0.2"
   },


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves n/a

----

### Before the change?

- `fast-content-type-parse` was refactored to use `content-type` in #807 but forgotten to be removed from dependencies.

### After the change?

- `fast-content-type-parse` is removed in dependencies

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

