### PR TITLE
fix: handle primitive JSON error bodies without throwing

### DIFF
--- a/src/fetch-wrapper.ts
+++ b/src/fetch-wrapper.ts
@@ -190,7 +190,7 @@ function isJSONResponse(mimetype: ContentType): boolean {
   );
 }
 
-function toErrorMessage(data: string | ArrayBuffer | Record<string, unknown>) {
+function toErrorMessage(data: unknown) {
   if (typeof data === "string") {
     return data;
   }
@@ -199,13 +199,20 @@ function toErrorMessage(data: string | ArrayBuffer | Record<string, unknown>) {
     return "Unknown error";
   }
 
-  if ("message" in data) {
+  // Guard the object-shaped branch before using the `in` operator: a JSON error
+  // body can be a primitive (`null`, a number, a boolean), and `"message" in
+  // data` throws a raw TypeError on non-object values. Primitives fall through
+  // to the generic unknown-error message below. See #819.
+  if (typeof data === "object" && data !== null && "message" in data) {
+    const objectData = data as Record<string, unknown>;
     const suffix =
-      "documentation_url" in data ? ` - ${data.documentation_url}` : "";
+      "documentation_url" in objectData
+        ? ` - ${objectData.documentation_url}`
+        : "";
 
-    return Array.isArray(data.errors)
-      ? `${data.message}: ${data.errors.map((v) => JSON.stringify(v)).join(", ")}${suffix}`
-      : `${data.message}${suffix}`;
+    return Array.isArray(objectData.errors)
+      ? `${objectData.message}: ${objectData.errors.map((v) => JSON.stringify(v)).join(", ")}${suffix}`
+      : `${objectData.message}${suffix}`;
   }
 
   return `Unknown error: ${JSON.stringify(data)}`;

--- a/test/request.test.ts
+++ b/test/request.test.ts
@@ -1293,6 +1293,38 @@ x//0u+zd/R/QRUzLOw4N72/Hu+UG6MNt5iDZFCtapRaKt6OvSBwy8w==
     ).rejects.toHaveProperty("message", "Unknown error: {}");
   });
 
+  it("primitive JSON error bodies should result in a RequestError, not a raw TypeError", async () => {
+    // Regression test for #819: an error response with content-type
+    // application/json but a primitive body (null, a number, a boolean) used to
+    // throw a raw TypeError from `"message" in data` before RequestError was
+    // constructed, losing the status/request/response fields.
+    const cases: Array<[string, string]> = [
+      ["null", "Unknown error: null"],
+      ["42", "Unknown error: 42"],
+      ["false", "Unknown error: false"],
+    ];
+
+    expect.assertions(cases.length * 4);
+
+    for (const [body, expectedMessage] of cases) {
+      const fakeFetch = async () =>
+        new Response(body, {
+          status: 400,
+          headers: { "content-type": "application/json" },
+        });
+
+      const error: any = await request("GET /demo", {
+        baseUrl: "https://request-errors-test.com",
+        request: { fetch: fakeFetch },
+      }).catch((error) => error);
+
+      expect(error.name).toEqual("HttpError");
+      expect(error.status).toEqual(400);
+      expect(error.message).toEqual(expectedMessage);
+      expect(error.response).toBeDefined();
+    }
+  });
+
   it("parses response bodies as JSON when Content-Type is application/scim+json", async () => {
     expect.assertions(1);
 


### PR DESCRIPTION
Fixes #819

## What was wrong

When an HTTP error response has `content-type: application/json` but the JSON body is a primitive value such as `null`, `42`, or `false`, `toErrorMessage()` threw a raw `TypeError` while building the error message:

```
TypeError: Cannot use 'in' operator to search for 'message' in null
```

This happens at `"message" in data` — the `in` operator is only valid on objects. Because it throws *before* `RequestError` is constructed, callers lose the documented `status`, `request`, and `response` fields.

The declared parameter type (`Record<string, unknown>`) hid the problem at compile time, but `getResponseData()` returns `any`, so a primitive JSON body reaches `toErrorMessage()` at runtime.

## Fix

Guard the object-shaped branch with `typeof data === "object" && data !== null` before using `in`. Primitive JSON bodies now fall through to the existing generic `Unknown error: <value>` path and a proper `RequestError` (`HttpError`) is thrown with `status`/`request`/`response` intact. The parameter type is widened to `unknown` to reflect that a parsed JSON body can be any value.

This does not change behavior for the common object-shaped GitHub error responses; it only affects primitive bodies that previously crashed (custom `fetch`, custom `baseUrl`, GHES/proxy responses, etc.).

## Test

Adds a regression test covering `null`, `42`, and `false` error bodies, asserting each rejects with an `HttpError` carrying `status: 400`, the expected `Unknown error: <value>` message, and a defined `response`. Verified it fails on `main` (raw `TypeError`) and passes with this change; the full suite remains green.