### PR TITLE
fix: don't decode application/octet-stream as text when charset is utf-8

### DIFF
--- a/src/fetch-wrapper.ts
+++ b/src/fetch-wrapper.ts
@@ -172,7 +172,11 @@ async function getResponseData(response: Response): Promise<any> {
     }
   } else if (
     mimetype.type.startsWith("text/") ||
-    mimetype.parameters.charset?.toLowerCase() === "utf-8"
+    // `application/octet-stream` is the canonical "arbitrary binary" type
+    // (RFC 2046) and must never be decoded as text, even when the response
+    // carries a (misleading) `charset=utf-8` parameter — see #751.
+    (mimetype.parameters.charset?.toLowerCase() === "utf-8" &&
+      mimetype.type !== "application/octet-stream")
   ) {
     return response.text().catch(noop);
   } else {

--- a/test/request-native-fetch.test.ts
+++ b/test/request-native-fetch.test.ts
@@ -406,6 +406,33 @@ x//0u+zd/R/QRUzLOw4N72/Hu+UG6MNt5iDZFCtapRaKt6OvSBwy8w==
     );
   });
 
+  it("Binary response with utf-8 charset is not mangled to text (#751)", async () => {
+    expect.assertions(3);
+
+    const payload =
+      "1f8b0800000000000003cb4f2ec9cfce2cd14dcbac28292d4ad5cd2f4ad74d4f2dd14d2c4acec82c4bd53580007d060a0050bfb9b9a90203c428741ac2313436343307222320dbc010a8dc5c81c194124b8905a5c525894540a714e5e797e05347481edd734304e41319ff41ae8e2ebeae7ab92964d801d46f66668227fe0d4d51e3dfc8d0c8d808284f75df6201233cfe951590627ba01d330a46c1281805a3806e000024cb59d6000a0000";
+
+    const request = await mockRequestHttpServer((req, res) => {
+      // Binary payload that (incorrectly) carries a charset parameter.
+      // It must still be returned as an ArrayBuffer, not decoded as text.
+      res.writeHead(200, {
+        "content-type": "application/octet-stream; charset=utf-8",
+        "content-length": "172",
+      });
+      res.end(Buffer.from(payload, "hex"));
+    });
+
+    const response = await request(
+      `GET ${request.baseUrlMockServer}/octokit-fixture-org/get-archive/legacy.tar.gz/master`,
+    );
+
+    expect(response.status).toEqual(200);
+    expect(response.data).toBeInstanceOf(ArrayBuffer);
+    expect(zlib.gunzipSync(Buffer.from(payload, "hex")).buffer).toEqual(
+      response.data,
+    );
+  });
+
   it("304 etag", async () => {
     expect.assertions(6);
 


### PR DESCRIPTION
Fixes the binary-mangling case of #751.

### Problem
`getResponseData()` decodes any response carrying `charset=utf-8` as text — including `application/octet-stream`, the canonical "arbitrary binary" media type (RFC 2046). A raw binary file (the reproduction in #751 fetches one with `mediaType: { format: "raw" }`) is run through `response.text()` and comes back as mangled string data instead of an `ArrayBuffer`.

### Fix
Exclude `application/octet-stream` from the charset-based text branch so it falls through to `arrayBuffer()`.

Deliberately narrow and zero-regression: `charset` alone can't tell text from binary (GitHub sends `charset=utf-8` on `application/vnd.github.v3.raw` text *and* on binary blobs), but `application/octet-stream` unambiguously means opaque bytes and must never be decoded as text. Genuinely textual responses — `text/*` and other `charset=utf-8` types like `application/vnd.github.v3.raw` — are unaffected (the existing "non-JSON response" test still passes).

### Test
Added a regression test: a binary payload served as `application/octet-stream; charset=utf-8` is returned as an `ArrayBuffer` and round-trips through `gunzip` intact. Full suite green (100 passed), `tsc` + prettier clean.

Broader binary types with a misleading `charset` could be handled with a fuller text/binary heuristic, but that's a larger design call — this closes the canonical, unambiguous case.
