### PR TITLE
fix: downgrade to content-type v2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@octokit/endpoint": "^11.0.5",
         "@octokit/request-error": "^7.1.2",
         "@octokit/types": "^18.0.0",
-        "content-type": "^3.0.0",
+        "content-type": "^2.0.0",
         "json-with-bigint": "^3.5.12",
         "universal-user-agent": "^7.0.2"
       },
@@ -1890,12 +1890,12 @@
       "license": "MIT"
     },
     "node_modules/content-type": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-3.0.0.tgz",
-      "integrity": "sha512-AIi5H6p0xk5uknXcN3/rmhP8jgp69OfSe/JuKiQAFprJ7UGw7mwj7m4XcmDzlrnJDG+cGpphAINGdU3g3g7kDw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
       "license": "MIT",
       "engines": {
-        "node": ">=22"
+        "node": ">=18"
       },
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@octokit/endpoint": "^11.0.5",
     "@octokit/request-error": "^7.1.2",
     "@octokit/types": "^18.0.0",
-    "content-type": "^3.0.0",
+    "content-type": "^2.0.0",
     "json-with-bigint": "^3.5.12",
     "universal-user-agent": "^7.0.2"
   },


### PR DESCRIPTION
v3 requires Node 22, which is higher than the current lowest supported version in Octokit

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #ISSUE_NUMBER

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* 

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* 

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [ ] No

----

